### PR TITLE
Fixed partial snapshot issue

### DIFF
--- a/cmd/snapshots_new.go
+++ b/cmd/snapshots_new.go
@@ -43,7 +43,7 @@ containing a backup of your Hass.io system.`,
 		addons, err := cmd.Flags().GetStringArray("addons")
 		log.WithField("addons", addons).Debug("addons")
 
-		if len(addons) >= 0 && err == nil && cmd.Flags().Changed("folders") {
+		if len(addons) >= 0 && err == nil && cmd.Flags().Changed("addons") {
 			options["addons"] = addons
 			command = "new/partial"
 		}


### PR DESCRIPTION
Fixed issue where attempting to do a partial snapshot with just addons specified would always do a full snapshot.