### PR TITLE
Add Home Assistant password reset commands

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var authCmd = &cobra.Command{
+	Use:     "authentication",
+	Aliases: []string{"auth", "au"},
+	Short:   "Authentication for Home Assistant users.",
+	Long: `
+The authentication command allows you to manage Home Assistant user accounts.
+`,
+	Example: `
+  ha authentication reset --username "JohnDoe" --password "123SuperSecret!"
+	`,
+}
+
+func init() {
+	log.Debug("Init authentication")
+
+	rootCmd.AddCommand(authCmd)
+}

--- a/cmd/auth_reset.go
+++ b/cmd/auth_reset.go
@@ -20,7 +20,7 @@ only work on some locations. For example, the Operating System CLI.
 `,
 	Example: `ha authentication reset --username "JohnDoe" --password "123SuperSecret!"`,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.WithField("args", args).Debug("core options")
+		log.WithField("args", args).Debug("auth reset")
 
 		section := "auth"
 		command := "reset"

--- a/cmd/auth_reset.go
+++ b/cmd/auth_reset.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var authResetCmd = &cobra.Command{
+	Use:     "reset",
+	Aliases: []string{"rst", "change"},
+	Short:   "Reset the password of a Home Assistant user.",
+	Long: `
+This command allows you to change a password of a Home Assistant user.
+Please note, this command is limited due to security reasons, and will
+only work on some locations. For example, the Operating System CLI.
+`,
+	Example: `ha authentication reset --username "JohnDoe" --password "123SuperSecret!"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("core options")
+
+		section := "auth"
+		command := "reset"
+		base := viper.GetString("endpoint")
+
+		options := make(map[string]interface{})
+
+		for _, value := range []string{
+			"username",
+			"password",
+		} {
+			val, err := cmd.Flags().GetString(value)
+			if val != "" && err == nil && cmd.Flags().Changed(value) {
+				options[value] = val
+			}
+		}
+
+		resp, err := helper.GenericJSONPost(base, section, command, options)
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+
+		return
+	},
+}
+
+func init() {
+	authResetCmd.Flags().String("username", "", "Username to reset the password for")
+	authResetCmd.Flags().String("password", "", "The new password to assign")
+	cobra.MarkFlagRequired(authResetCmd.Flags(), "username")
+	cobra.MarkFlagRequired(authResetCmd.Flags(), "password")
+	authCmd.AddCommand(authResetCmd)
+}


### PR DESCRIPTION
Adds support for the new Home Assistant password reset command.

Closes #189

Please note, while this command seems to be working fine, the Supervisor seems to have an issue with the password reset.