### PR TITLE
Fix execution of rootCmd PreRun

### DIFF
--- a/cmd/core.go
+++ b/cmd/core.go
@@ -25,6 +25,7 @@ Home Assistant Core.
   ha core update
 	ha core update --version 0.97.2`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		rootCmd.PersistentPreRun(cmd, args)
 		for _, arg := range os.Args {
 			if arg == "homeassistant" || arg == "ha" {
 				cmd.PrintErrf("The use of '%s' is deprecated, please use 'core' instead!\n", arg)

--- a/cmd/os.go
+++ b/cmd/os.go
@@ -20,6 +20,7 @@ it provides a command to import configurations from a USB stick.`,
   ha os info
 	ha os update`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		rootCmd.PersistentPreRun(cmd, args)
 		for _, arg := range os.Args {
 			if arg == "hassos" {
 				cmd.PrintErrf("The use of '%s' is deprecated, please use 'os' instead!\n", arg)


### PR DESCRIPTION
The `PersistentPreRun` on commands does not bubble up to parent commands.

For the `os` and `core` commands have their own, this PR makes sure the parent command (rootCmd) is also executed.

This fixes things like the ProgressSpinner.