### PR TITLE
Fix spinner overwrite and deprecation false-positive

### DIFF
--- a/cmd/core.go
+++ b/cmd/core.go
@@ -25,12 +25,12 @@ Home Assistant Core.
   ha core update
 	ha core update --version 0.97.2`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		rootCmd.PersistentPreRun(cmd, args)
-		for _, arg := range os.Args {
-			if arg == "homeassistant" || arg == "ha" {
+		for idx, arg := range os.Args {
+			if idx != 0 && (arg == "homeassistant" || arg == "ha") {
 				cmd.PrintErrf("The use of '%s' is deprecated, please use 'core' instead!\n", arg)
 			}
 		}
+		rootCmd.PersistentPreRun(cmd, args)
 	},
 }
 

--- a/cmd/os.go
+++ b/cmd/os.go
@@ -20,12 +20,12 @@ it provides a command to import configurations from a USB stick.`,
   ha os info
 	ha os update`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		rootCmd.PersistentPreRun(cmd, args)
 		for _, arg := range os.Args {
 			if arg == "hassos" {
 				cmd.PrintErrf("The use of '%s' is deprecated, please use 'os' instead!\n", arg)
 			}
 		}
+		rootCmd.PersistentPreRun(cmd, args)
 	},
 }
 


### PR DESCRIPTION
- The order of the `PersistantPreRun` could mess with the Spinner (the spinner could overwrite the deprecation message because of timing in a terminal).

- The new CLI command is `ha`, but `ha` is also deprecated as sub-command. I've adjusted the deprecation logic to be able to handle that.