### PR TITLE
Print addition error message on failed auth reset

### DIFF
--- a/cmd/auth_reset.go
+++ b/cmd/auth_reset.go
@@ -40,6 +40,7 @@ only work on some locations. For example, the Operating System CLI.
 
 		resp, err := helper.GenericJSONPost(base, section, command, options)
 		if err != nil {
+			cmd.PrintErrln("this command is limited due to security reasons, and will only work on some locations. For example, the Operating System terminal.")
 			fmt.Println(err)
 			ExitWithError = true
 		} else {


### PR DESCRIPTION
Adds an additional output message when auth reset fails when the used API token doesn't work.

Closes #204