### PR TITLE
Default to self for addon info command

### DIFF
--- a/cmd/addons_info.go
+++ b/cmd/addons_info.go
@@ -24,7 +24,6 @@ is provided, information about a specific add-on.
   ha addons info
   ha addons info core_ssh
 `,
-	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		log.WithField("args", args).Debug("addons info")
 
@@ -42,7 +41,10 @@ is provided, information about a specific add-on.
 
 		request := helper.GetJSONRequest()
 
-		slug := args[0]
+		slug := "self"
+		if len(args) > 0 {
+			slug = args[0]
+		}
 
 		request.SetPathParams(map[string]string{
 			"slug": slug,


### PR DESCRIPTION
fixes #217 

`ha addon info` would not work and required an argument (add-on slug).

Changed this behavior to use the default of `self` as the slug when the add-on slug isn't specified.