### PR TITLE
Fix snapshot example string

### DIFF
--- a/cmd/snapshots_new.go
+++ b/cmd/snapshots_new.go
@@ -19,7 +19,7 @@ snapshot containing a backup of your Home Assistant system.`,
 	Example: `
   ha snapshots new
   ha snapshots new --addons core_ssh --addons core_mosquitto
-  ha snapshots new --folders config
+  ha snapshots new --folders homeassistant
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.WithField("args", args).Debug("snapshots new")


### PR DESCRIPTION
I noticed that the snapshot example (help command) does not work and is therefore misleading. The folder has to be called "homeassistant" instead of "config".