### PR TITLE
Wait until Supervisor has been started before printing the banner

### DIFF
--- a/cmd/banner.go
+++ b/cmd/banner.go
@@ -66,7 +66,7 @@ var bannerCmd = &cobra.Command{
 		fmt.Print(haBanner)
 		fmt.Println()
 
-		nowait, err := cmd.Flags().GetBool("no-wait-for-supervisor")
+		nowait, err := cmd.Flags().GetBool("no-wait")
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true
@@ -163,5 +163,5 @@ var bannerCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(bannerCmd)
-	bannerCmd.Flags().Bool("no-wait-for-supervisor", false, "Don't wait until supervisor is started")
+	bannerCmd.Flags().Bool("no-wait", false, "Don't wait until Supervisor is started")
 }

--- a/cmd/banner.go
+++ b/cmd/banner.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -20,13 +21,12 @@ const haBanner = `
 Welcome to the Home Assistant command line.
 `
 
-func pokeAPI(section string, command string) (outdata *(map[string]interface{})) {
+func supervisorGet(section string, command string) (outdata *(map[string]interface{}), err error) {
 	base := viper.GetString("endpoint")
 
 	resp, err := helper.GenericJSONGet(base, section, command)
 	if err != nil {
-		fmt.Println(err)
-		ExitWithError = true
+		return nil, err
 	}
 
 	var data *helper.Response
@@ -36,16 +36,13 @@ func pokeAPI(section string, command string) (outdata *(map[string]interface{}))
 		data = resp.Error().(*helper.Response)
 	}
 	if data.Result == "ok" {
-		if len(data.Data) == 0 {
-			fmt.Println("Command completed successfully.")
-		} else {
+		if len(data.Data) > 0 {
 			outdata = &(data.Data)
 		}
 	} else {
-		fmt.Println("No result from API - Supervisor not (yet) running.")
-		ExitWithError = true
+		return nil, fmt.Errorf("Error returned from Supervisor: %s", data.Message)
 	}
-	return
+	return outdata, nil
 }
 
 func getAddresses(addresses []interface{}) string {
@@ -69,9 +66,35 @@ var bannerCmd = &cobra.Command{
 		fmt.Print(haBanner)
 		fmt.Println()
 
-		fmt.Println("System information")
+		nowait, err := cmd.Flags().GetBool("no-wait-for-supervisor")
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		}
 
-		netinfo := pokeAPI("network", "info")
+		if !nowait {
+			for i := 0; i < 60; i++ {
+				// We could use ping here, but Supervisor loads networking data asynchronously.
+				// Networking info are very useful, so wait until networking data have been
+				// loaded...
+				netinfo, err := supervisorGet("network", "info")
+				if err == nil && netinfo != nil {
+					break
+				}
+				if i == 0 {
+					fmt.Println("Waiting for Supervisor to startup...")
+				}
+				time.Sleep(1 * time.Second)
+			}
+		}
+
+		fmt.Println("System information")
+		netinfo, err := supervisorGet("network", "info")
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+			return
+		}
 		if netinfo == nil {
 			return
 		}
@@ -105,11 +128,21 @@ var bannerCmd = &cobra.Command{
 		fmt.Println()
 
 		// Print Host URL
-		hostinfo := pokeAPI("host", "info")
+		hostinfo, err := supervisorGet("host", "info")
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+			return
+		}
 		if hostinfo == nil {
 			return
 		}
-		coreinfo := pokeAPI("core", "info")
+		coreinfo, err := supervisorGet("core", "info")
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+			return
+		}
 		if coreinfo == nil {
 			return
 		}
@@ -130,4 +163,5 @@ var bannerCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(bannerCmd)
+	bannerCmd.Flags().Bool("no-wait-for-supervisor", false, "Don't wait until supervisor is started")
 }

--- a/cmd/banner.go
+++ b/cmd/banner.go
@@ -79,7 +79,11 @@ var bannerCmd = &cobra.Command{
 				// loaded...
 				netinfo, err := supervisorGet("network", "info")
 				if err == nil && netinfo != nil {
-					break
+
+					netifaces, exist := (*netinfo)["interfaces"]
+					if exist && len(netifaces.([]interface{})) > 0 {
+						break
+					}
 				}
 				if i == 0 {
 					fmt.Println("Waiting for Supervisor to startup...")


### PR DESCRIPTION
At startup, the Supervisor API returns an error with the message that
the Supervisor is still in setup. This leads to an empty banner, which
is not that helpful. Wait by default until the Supervisor returns useful
data.