### PR TITLE
Increase timeouts for start/stop/restart commands

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -17,6 +17,9 @@ import (
 )
 
 const DefaultTimeout = 30 * time.Second
+const ContainerOperationTimeout = 10 * time.Minute
+const ContainerDownloadTimeout = 1 * time.Hour
+const SnapshotTimeout = 3 * time.Hour
 
 var client *resty.Client
 

--- a/cmd/addons_install.go
+++ b/cmd/addons_install.go
@@ -36,7 +36,7 @@ This command allows you to install a Home Assistant add-on from the commandline.
 			return
 		}
 
-		request := helper.GetJSONRequest()
+		request := helper.GetJSONRequestTimeout(helper.ContainerDownloadTimeout)
 
 		slug := args[0]
 

--- a/cmd/addons_rebuild.go
+++ b/cmd/addons_rebuild.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	resty "github.com/go-resty/resty/v2"
 	helper "github.com/home-assistant/cli/client"
@@ -40,7 +39,7 @@ add-on.
 			return
 		}
 
-		request := helper.GetJSONRequestTimeout(10 * time.Minute)
+		request := helper.GetJSONRequestTimeout(helper.ContainerOperationTimeout)
 
 		slug := args[0]
 

--- a/cmd/addons_restart.go
+++ b/cmd/addons_restart.go
@@ -36,7 +36,7 @@ Restart a Home Assistant add-on
 			return
 		}
 
-		request := helper.GetJSONRequest()
+		request := helper.GetJSONRequestTimeout(helper.ContainerOperationTimeout)
 
 		slug := args[0]
 

--- a/cmd/addons_stop.go
+++ b/cmd/addons_stop.go
@@ -36,7 +36,7 @@ This command allows you to manually start a stopped Home Assistant add-on
 			return
 		}
 
-		request := helper.GetJSONRequest()
+		request := helper.GetJSONRequestTimeout(helper.ContainerOperationTimeout)
 
 		slug := args[0]
 

--- a/cmd/addons_uninstall.go
+++ b/cmd/addons_uninstall.go
@@ -36,7 +36,7 @@ This command allows you to uninstall a Home Assistant add-on.
 			return
 		}
 
-		request := helper.GetJSONRequest()
+		request := helper.GetJSONRequestTimeout(helper.ContainerOperationTimeout)
 
 		slug := args[0]
 

--- a/cmd/core_rebuild.go
+++ b/cmd/core_rebuild.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -28,7 +27,7 @@ Don't worry, this does not delete your config.`,
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, 10*time.Minute)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/core_restart.go
+++ b/cmd/core_restart.go
@@ -25,7 +25,7 @@ Restart the Home Assistant Core instance running on your system`,
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/core_start.go
+++ b/cmd/core_start.go
@@ -26,7 +26,7 @@ your system. This, of course, only applies when it has been stopped.`,
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/core_stop.go
+++ b/cmd/core_stop.go
@@ -26,7 +26,7 @@ your system.`,
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/core_update.go
+++ b/cmd/core_update.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -35,7 +34,7 @@ running on your system to the latest version or the version specified.`,
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/multicast_restart.go
+++ b/cmd/multicast_restart.go
@@ -24,7 +24,7 @@ var multicastRestartCmd = &cobra.Command{
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/multicast_update.go
+++ b/cmd/multicast_update.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -36,7 +35,7 @@ Multicast server, to the latest version or the version specified.
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 
 		if err != nil {

--- a/cmd/observer_update.go
+++ b/cmd/observer_update.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -36,7 +35,7 @@ observer, to the latest version or the version specified.
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 
 		if err != nil {

--- a/cmd/snapshots_new.go
+++ b/cmd/snapshots_new.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -58,7 +57,7 @@ snapshot containing a backup of your Home Assistant system.`,
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 3*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.SnapshotTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/snapshots_restore.go
+++ b/cmd/snapshots_restore.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	resty "github.com/go-resty/resty/v2"
 	helper "github.com/home-assistant/cli/client"
@@ -30,7 +29,7 @@ take Home Assistant snapshot backup on your system.`,
 		command := "restore/full"
 		base := viper.GetString("endpoint")
 
-		request := helper.GetJSONRequestTimeout(3 * time.Hour)
+		request := helper.GetJSONRequestTimeout(helper.SnapshotTimeout)
 
 		options := make(map[string]interface{})
 

--- a/cmd/supervisor_repair.go
+++ b/cmd/supervisor_repair.go
@@ -28,7 +28,7 @@ the Home Assistant Supervisor will try to resolve these.
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/supervisor_restart.go
+++ b/cmd/supervisor_restart.go
@@ -24,7 +24,7 @@ Restart the Supervisor internal, this can solve healthy issues.`,
 		command := "restart"
 		base := viper.GetString("endpoint")
 
-		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/supervisor_update.go
+++ b/cmd/supervisor_update.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -36,7 +35,7 @@ or the version specified.`,
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
Centralize timeout default values in helper. Increase timeouts related
to Container operations such as start/stop/restart commands.

Fixes: #297, #298 