### PR TITLE
audio: remove trailing " from help example

### DIFF
--- a/cmd/audio.go
+++ b/cmd/audio.go
@@ -13,7 +13,7 @@ var audioCmd = &cobra.Command{
 Control audio devices.
 `,
 	Example: `
-  ha audio info"
+  ha audio info
 	`,
 }
 


### PR DESCRIPTION
The text "ha audio info" had a trailing " that was not needed and looked out of place.

Remove it as it is not necessary.