### PR TITLE
Use consts for timeouts in all cases

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -19,6 +19,7 @@ import (
 const DefaultTimeout = 30 * time.Second
 const ContainerOperationTimeout = 10 * time.Minute
 const ContainerDownloadTimeout = 1 * time.Hour
+const OsDownloadTimeout = 1 * time.Hour
 const BackupTimeout = 3 * time.Hour
 
 var client *resty.Client

--- a/cmd/audio_restart.go
+++ b/cmd/audio_restart.go
@@ -24,7 +24,7 @@ var audioRestartCmd = &cobra.Command{
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/audio_update.go
+++ b/cmd/audio_update.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -35,7 +34,7 @@ instance running on your system to the latest version or the version specified.`
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/cli_update.go
+++ b/cmd/cli_update.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -36,7 +35,7 @@ CLI backend, to the latest version or the version specified.
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 
 		if err != nil {

--- a/cmd/core_check.go
+++ b/cmd/core_check.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -29,7 +28,7 @@ Home Assistant Core.`,
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 
 		if err != nil {

--- a/cmd/dns_restart.go
+++ b/cmd/dns_restart.go
@@ -24,7 +24,7 @@ var dnsRestartCmd = &cobra.Command{
 		base := viper.GetString("endpoint")
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPost(base, section, command, nil)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, nil, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/dns_update.go
+++ b/cmd/dns_update.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -36,7 +35,7 @@ DNS server, to the latest version or the version specified.
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 
 		if err != nil {

--- a/cmd/os_update.go
+++ b/cmd/os_update.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -37,7 +36,7 @@ Operating System to the latest version or the version specified.
 		}
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, 1*time.Hour)
+		resp, err := helper.GenericJSONPostTimeout(base, section, command, options, helper.OsDownloadTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
This replaces hard coded timeouts with an equal const value from the
helper module. All values remain the same except for core check comand,
which now uses a 10 minute timeout instead of 1 hour
(ContainerOperationTimeout).