### PR TITLE
Revamp ha core options subcommand

### DIFF
--- a/cmd/core_options.go
+++ b/cmd/core_options.go
@@ -29,13 +29,17 @@ instance running on your Home Assistant system.`,
 
 		for _, value := range []string{
 			"image",
-			"last_version",
-			"password",
 			"refresh_token",
+			"audio_output",
+			"audio_input",
 		} {
 			val, err := cmd.Flags().GetString(value)
-			if val != "" && err == nil && cmd.Flags().Changed(value) {
-				options[value] = val
+			if err == nil && cmd.Flags().Changed(value) {
+				if val == "" {
+					options[value] = nil
+				} else {
+					options[value] = val
+				}
 			}
 		}
 
@@ -49,14 +53,15 @@ instance running on your Home Assistant system.`,
 			options["wait_boot"] = waitBoot
 		}
 
-		ssl, err := cmd.Flags().GetBool("ssl")
-		if err == nil && cmd.Flags().Changed("ssl") {
-			options["ssl"] = ssl
-		}
-
-		watchdog, err := cmd.Flags().GetBool("watchdog")
-		if err == nil && cmd.Flags().Changed("watchdog") {
-			options["watchdog"] = watchdog
+		for _, value := range []string{
+			"boot",
+			"ssl",
+			"watchdog",
+		} {
+			val, err := cmd.Flags().GetBool(value)
+			if err == nil && cmd.Flags().Changed(value) {
+				options[value] = val
+			}
 		}
 
 		resp, err := helper.GenericJSONPost(base, section, command, options)
@@ -70,13 +75,14 @@ instance running on your Home Assistant system.`,
 }
 
 func init() {
+	coreOptionsCmd.Flags().Bool("boot", true, "Start Core on boot")
 	coreOptionsCmd.Flags().String("image", "", "Optional image")
-	coreOptionsCmd.Flags().String("last_version", "", "Optional for custom image")
-	coreOptionsCmd.Flags().Int("port", 8123, "Port for access Home Assistant")
+	coreOptionsCmd.Flags().Int("port", 8123, "Port to access Home Assistant Core")
 	coreOptionsCmd.Flags().Bool("ssl", false, "Use SSL")
-	coreOptionsCmd.Flags().String("password", "", "API password")
-	coreOptionsCmd.Flags().String("refresh_token", "", "Refresh token")
 	coreOptionsCmd.Flags().Bool("watchdog", true, "Use watchdog")
-	coreOptionsCmd.Flags().Int("wait_boot", 600, "wait_boot")
+	coreOptionsCmd.Flags().Int("wait_boot", 600, "Time to wait for Core to startup")
+	coreOptionsCmd.Flags().String("refresh_token", "", "Refresh token")
+	coreOptionsCmd.Flags().String("audio_input", "", "Profile name for audio input")
+	coreOptionsCmd.Flags().String("audio_output", "", "Profile name for audio output")
 	coreCmd.AddCommand(coreOptionsCmd)
 }


### PR DESCRIPTION
Remove options which no longer exist and add newly added options. Also
make it possible to clear string settings by using an empty string ("")
which gets translated to null.

Related-to: https://github.com/home-assistant/developers.home-assistant/pull/1146