### PR TITLE
Add store add/remove APIs to CLI

### DIFF
--- a/cmd/store.go
+++ b/cmd/store.go
@@ -19,6 +19,7 @@ for managing stores that provide later add-ons.`,
 	Example: `
   ha store addons install core_ssh
   ha store add https://github.com/home-assistant/addons-example
+  ha store delete 94cfad5a 
   ha store reload`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.WithField("args", args).Debug("store")

--- a/cmd/store_repositories_add.go
+++ b/cmd/store_repositories_add.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	resty "github.com/go-resty/resty/v2"
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var storeRepositoriesAddCmd = &cobra.Command{
+	Use:     "add [repository]",
+	Aliases: []string{"set", "new"},
+	Short:   "Add new repository to Home Assistant store",
+	Long: `
+Add new repository of add-ons to the Home Assistant store.
+`,
+	Example: `
+ha store add https://github.com/home-assistant/addons-example
+`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("store add")
+
+		section := "store"
+		command := "repositories"
+
+		url, err := helper.URLHelper(section, command)
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+			return
+		}
+
+		options := map[string]string{}
+
+		request := helper.GetJSONRequest()
+
+		repository := args[0]
+		options["repository"] = repository
+
+		if len(options) > 0 {
+			log.WithField("options", options).Debug("Request body")
+			request.SetBody(options)
+		}
+
+		resp, err := request.Post(url)
+
+		// returns 200 OK or 400, everything else is wrong
+		if err == nil {
+			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
+				err = errors.New("unexpected server response")
+				log.Error(err)
+			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
+				err = errors.New("API did not return a JSON response")
+				log.Error(err)
+			}
+		}
+
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	storeCmd.AddCommand(storeRepositoriesAddCmd)
+}

--- a/cmd/store_repositories_delete.go
+++ b/cmd/store_repositories_delete.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	resty "github.com/go-resty/resty/v2"
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var storeRepositoriesDeleteCmd = &cobra.Command{
+	Use:     "delete [slug]",
+	Aliases: []string{"del", "remove"},
+	Short:   "Delete repository from Home Assistant store",
+	Long: `
+Remove a repository of add-ons that isn't in use from the Home Assistant store.
+`,
+	Example: `
+ha store delete 94cfad5a
+`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("store delete")
+
+		section := "store"
+		command := "repositories/{slug}"
+
+		url, err := helper.URLHelper(section, command)
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+			return
+		}
+
+		request := helper.GetJSONRequest()
+
+		slug := args[0]
+		request.SetPathParams(map[string]string{
+			"slug": slug,
+		})
+
+		resp, err := request.Delete(url)
+
+		// returns 200 OK or 400, everything else is wrong
+		if err == nil {
+			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
+				err = errors.New("unexpected server response")
+				log.Error(err)
+			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
+				err = errors.New("API did not return a JSON response")
+				log.Error(err)
+			}
+		}
+
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	storeCmd.AddCommand(storeRepositoriesDeleteCmd)
+}


### PR DESCRIPTION
Add options for adding and removing a repository to store section.

Parent Supervisor PR: https://github.com/home-assistant/supervisor/pull/3649