### PR TITLE
Fix `store addons`

### DIFF
--- a/cmd/store_addons.go
+++ b/cmd/store_addons.go
@@ -22,7 +22,7 @@ commands for installing or update them.`,
 		log.WithField("args", args).Debug("store")
 
 		section := "store"
-		command := "addons"
+		command := ""
 
 		resp, err := helper.GenericJSONGet(section, command)
 		if err != nil {


### PR DESCRIPTION
Without this:
```shellsession
~ $ ha store addons
json: cannot unmarshal array into Go struct field Response.data of type map[string]interface {}
```
Plain `ha store` works and is the same, but as the `addons` subcommand exists, I suppose we should make it work, too.