### PR TITLE
Fix restore example

### DIFF
--- a/cmd/backups_restore.go
+++ b/cmd/backups_restore.go
@@ -19,7 +19,7 @@ take Home Assistant backup on your system.`,
 	Example: `
   ha backups restore c1a07617
   ha backups restore c1a07617 --addons core_ssh --addons core_mosquitto
-  ha backups restore c1a07617 --folders config`,
+  ha backups restore c1a07617 --folders homeassistant`,
 	ValidArgsFunction: backupsCompletions,
 	Args:              cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
To restore only HA core, `--folders homeassistant` is the correct command, not `--folders config`

See supervisor backup manager: https://github.com/home-assistant/supervisor/blob/main/supervisor/backups/manager.py#L387
```
        if FOLDER_HOMEASSISTANT in folder_list:
            folder_list.remove(FOLDER_HOMEASSISTANT)
            homeassistant = True
```