### PR TITLE
Fix io/ioutil deprecation warnings

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"path"
 	"time"
@@ -126,7 +125,7 @@ func ShowJSONResponse(resp *resty.Response) (success bool) {
 		success = true
 		body := resp.RawBody()
 		defer body.Close()
-		if b, err := ioutil.ReadAll(body); err == nil {
+		if b, err := io.ReadAll(body); err == nil {
 			fmt.Print(string(b))
 		}
 		return

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -21,7 +21,6 @@ package spinner
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -48,7 +47,7 @@ func New(cs []string, d time.Duration, options ...Option) *Spinner {
 		Delay:    d,
 		chars:    cs,
 		lock:     &sync.RWMutex{},
-		Writer:   ioutil.Discard,
+		Writer:   io.Discard,
 		active:   false,
 		stopChan: make(chan struct{}, 1),
 	}


### PR DESCRIPTION
The [io/ioutil](https://tip.golang.org/pkg/io/ioutil/) was deprecated in Go 1.16.

https://tip.golang.org/doc/go1.16#ioutil