### PR TITLE
Include share as mount usage option

### DIFF
--- a/cmd/mounts.go
+++ b/cmd/mounts.go
@@ -46,7 +46,7 @@ func addMountFlags(cmd *cobra.Command) {
 		return []string{"cifs", "nfs"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.RegisterFlagCompletionFunc("usage", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"backup", "media"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"backup", "media", "share"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.RegisterFlagCompletionFunc("server", cobra.NoFileCompletions)
 	cmd.RegisterFlagCompletionFunc("port", portCompletions)


### PR DESCRIPTION
Include share as mount usage option as per https://github.com/home-assistant/supervisor/pull/4318