### PR TITLE
Add CLI support for new Green LED APIs

### DIFF
--- a/cmd/os_boards_green.go
+++ b/cmd/os_boards_green.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var osBoardsGreenCmd = &cobra.Command{
+	Use:     "green",
+	Aliases: []string{"grn"},
+	Short:   "See or change settings of the current Green board",
+	Long: `
+This command allows you to see or change settings of the Green board that Home
+Assistant is running on.`,
+	Example: `
+  ha os boards green`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("os boards green")
+
+		section := "os"
+		command := "boards/green"
+
+		resp, err := helper.GenericJSONGet(section, command)
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	osBoardsCmd.AddCommand(osBoardsGreenCmd)
+}

--- a/cmd/os_boards_green_options.go
+++ b/cmd/os_boards_green_options.go
@@ -15,7 +15,7 @@ var osBoardsGreenOptionsCmd = &cobra.Command{
 	Short:   "Change settings of the current Green board",
 	Long: `
 This command allows you to change settings of the Green board that Home
-Assistant is running on. A host reboot is required for changes to take effect.`,
+Assistant is running on.`,
 	Example: `
   ha os boards green options --activity-led=false`,
 	ValidArgsFunction: cobra.NoFileCompletions,
@@ -31,7 +31,7 @@ Assistant is running on. A host reboot is required for changes to take effect.`,
 		for _, value := range []string{
 			"activity-led",
 			"power-led",
-			"user-led",
+			"system-health-led",
 		} {
 			data, err := cmd.Flags().GetBool(value)
 			if err == nil && cmd.Flags().Changed(value) {
@@ -50,12 +50,12 @@ Assistant is running on. A host reboot is required for changes to take effect.`,
 }
 
 func init() {
-	osBoardsGreenOptionsCmd.Flags().Bool("activity-led", true, "Enable/disable the activity LED")
-	osBoardsGreenOptionsCmd.Flags().Bool("power-led", true, "Enable/disable the power LED")
-	osBoardsGreenOptionsCmd.Flags().Bool("user-led", true, "Enable/disable the user LED")
+	osBoardsGreenOptionsCmd.Flags().Bool("activity-led", true, "Enable/disable the green activity LED")
+	osBoardsGreenOptionsCmd.Flags().Bool("power-led", true, "Enable/disable the white power LED")
+	osBoardsGreenOptionsCmd.Flags().Bool("system-health-led", true, "Enable/disable the yellow system health LED")
 	osBoardsGreenOptionsCmd.Flags().Lookup("activity-led").NoOptDefVal = "true"
 	osBoardsGreenOptionsCmd.Flags().Lookup("power-led").NoOptDefVal = "true"
-	osBoardsGreenOptionsCmd.Flags().Lookup("user-led").NoOptDefVal = "true"
+	osBoardsGreenOptionsCmd.Flags().Lookup("system-health-led").NoOptDefVal = "true"
 
 	osBoardsGreenCmd.AddCommand(osBoardsGreenOptionsCmd)
 }

--- a/cmd/os_boards_green_options.go
+++ b/cmd/os_boards_green_options.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var osBoardsGreenOptionsCmd = &cobra.Command{
+	Use:     "options",
+	Aliases: []string{"option", "opt", "opts", "op"},
+	Short:   "Change settings of the current Green board",
+	Long: `
+This command allows you to change settings of the Green board that Home
+Assistant is running on. A host reboot is required for changes to take effect.`,
+	Example: `
+  ha os boards green options --activity-led=false`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("os boards green options")
+
+		section := "os"
+		command := "boards/green"
+
+		options := make(map[string]interface{})
+
+		for _, value := range []string{
+			"activity-led",
+			"power-led",
+			"user-led",
+		} {
+			data, err := cmd.Flags().GetBool(value)
+			if err == nil && cmd.Flags().Changed(value) {
+				options[strings.Replace(value, "-", "_", -1)] = data
+			}
+		}
+
+		resp, err := helper.GenericJSONPost(section, command, options)
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	osBoardsGreenOptionsCmd.Flags().Bool("activity-led", true, "Enable/disable the activity LED")
+	osBoardsGreenOptionsCmd.Flags().Bool("power-led", true, "Enable/disable the power LED")
+	osBoardsGreenOptionsCmd.Flags().Bool("user-led", true, "Enable/disable the user LED")
+	osBoardsGreenOptionsCmd.Flags().Lookup("activity-led").NoOptDefVal = "true"
+	osBoardsGreenOptionsCmd.Flags().Lookup("power-led").NoOptDefVal = "true"
+	osBoardsGreenOptionsCmd.Flags().Lookup("user-led").NoOptDefVal = "true"
+
+	osBoardsGreenCmd.AddCommand(osBoardsGreenOptionsCmd)
+}


### PR DESCRIPTION
Add CLI support for the new APIs to set LEDs on Green added in https://github.com/home-assistant/supervisor/pull/4556