### PR TITLE
Add support for making read-only mounts

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: codespell-project/actions-codespell@v2.0
+        with:
+          skip: ./.git,./go.sum

--- a/cmd/mounts.go
+++ b/cmd/mounts.go
@@ -42,7 +42,9 @@ func addMountFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("password", "p", "", "Password to use for authentication (cifs mounts only)")
 	cmd.Flags().StringP("version", "v", "", "Version to use for the mount (cifs mounts only)")
 	cmd.Flags().StringP("path", "a", "", "Path to mount (nfs mounts only)")
+	cmd.Flags().BoolP("read-only", "ro", false, "Is mount read-only (not available for backup mounts)")
 
+	cmd.Flags().Lookup("read-only").NoOptDefVal = "true"
 	cmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"cifs", "nfs"}, cobra.ShellCompDirectiveNoFileComp
 	})
@@ -78,6 +80,11 @@ func mountFlagsToOptions(cmd *cobra.Command, options map[string]interface{}) {
 	val, err := cmd.Flags().GetInt("port")
 	if val > 0 && err == nil && cmd.Flags().Changed("port") {
 		options["port"] = val
+	}
+
+	roVal, roErr := cmd.Flags().GetBool("read-only")
+	if roErr == nil && cmd.Flags().Changed("read-only") {
+		options["read_only"] = roVal
 	}
 }
 

--- a/cmd/mounts_add.go
+++ b/cmd/mounts_add.go
@@ -20,7 +20,7 @@ Add and configure a new mount in Supervisor.
 	Example: `
   ha mounts add my_share --usage media --type cifs --server server.local --share media
 `,
-	ValidArgsFunction: cobra.NoFileCompletions,
+	ValidArgsFunction: mountsCompletions,
 	Args:              cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		log.WithField("args", args).Debug("mounts add")


### PR DESCRIPTION
Add support for making read-only mounts. CLI support for https://github.com/home-assistant/supervisor/pull/4872

Also have codespell ignore go.sum since its generated, it was throwing an error.