### PR TITLE
Fix a misnamed `homeassistant-exclude-database`

### DIFF
--- a/cmd/backups_new.go
+++ b/cmd/backups_new.go
@@ -72,7 +72,7 @@ backup.`,
 
 		ExcludeDB, err := cmd.Flags().GetBool("homeassistant-exclude-database")
 		if err == nil && cmd.Flags().Changed("homeassistant-exclude-database") {
-			options["homeassistant-exclude-database"] = ExcludeDB
+			options["homeassistant_exclude_database"] = ExcludeDB
 		}
 
 		ProgressSpinner.Start()


### PR DESCRIPTION
Replica of #457, but for `homeassistant-exclude-database`. See https://github.com/home-assistant/cli/issues/457#issuecomment-1942474696