### PR TITLE
Allow listing of HA users via admin CLI

### DIFF
--- a/cmd/auth_list.go
+++ b/cmd/auth_list.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var authListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List all Home Assistant users.",
+	Long: `
+This command allows you to list all Home Assistant users on the system.
+Please note, this command is limited due to security reasons, and will
+only work on some locations. For example, the Operating System CLI.
+`,
+	Example: `
+  ha authentication list
+`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("auth list")
+
+		section := "auth"
+		command := "list"
+
+		resp, err := helper.GenericJSONGet(section, command)
+		if err != nil {
+			cmd.PrintErrln("this command is limited due to security reasons, and will only work on some locations. For example, the Operating System terminal.")
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	authCmd.AddCommand(authListCmd)
+}


### PR DESCRIPTION
CLI support for https://github.com/home-assistant/supervisor/pull/4912