### PR TITLE
Add device wipe command to CLI

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -212,7 +212,7 @@ func AskForConfirmation(prompt string, tries int) bool {
 		}
 
 		// If user enters no or n then stop. Else retry since they entered something unknown
-		if res[0] == 'n' {
+		if len(res) > 0 && res[0] == 'n' {
 			return false
 		}
 	}

--- a/client/helper.go
+++ b/client/helper.go
@@ -1,10 +1,12 @@
 package client
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"path"
 	"time"
 
@@ -186,4 +188,33 @@ func StreamTextResponse(resp *resty.Response) (success bool) {
 		}
 	}
 	return
+}
+
+func AskForConfirmation(prompt string, tries int) bool {
+	reader := bufio.NewReader(os.Stdin)
+	if tries <= 0 {
+		tries = 2
+	}
+
+	for ; tries > 0; tries-- {
+		fmt.Printf("%s [enter YES to confirm] ", prompt)
+
+		res, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatalf("error: %v", err)
+			continue
+		}
+
+		// Require YES or yes explicitly to confirm
+		res = strings.ToLower(strings.TrimSpace(res))
+		if res == "yes" {
+			return true
+		}
+
+		// If user enters no or n then stop. Else retry since they entered something unknown
+		if res[0] == 'n' {
+			return false
+		}
+	}
+	return false
 }

--- a/cmd/os_datadisk_wipe.go
+++ b/cmd/os_datadisk_wipe.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var osDataDiskWipeCmd = &cobra.Command{
+	Use:     "wipe",
+	Aliases: []string{"wipe", "reset", "erase"},
+	Short:   "Wipe the Home Assistant Operating-System data partition",
+	Long: `
+This command will wipe all config for addons and Home Assistant and any locally
+stored data in config, backups, media, etc. The machine will reboot during this.
+
+After the reboot completes the latest stable version of Home Assistant and Supervisor
+will be downloaded. Once the process is complete you will see onboarding, like
+during initial setup.
+
+The Operating System will not change during this. This includes OS level settings
+such as network settings.
+
+Please note, this command is limited due to security reasons, and will
+only work on some locations. For example, the Operating System CLI.
+`,
+	Example: `
+  ha os datadisk wipe
+`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("os datadisk wipe")
+
+		section := "os"
+		command := "datadisk/wipe"
+
+		if helper.AskForConfirmation(`
+This will completely wipe the datadisk. This process is irreversible.
+Are you sure you want to proceed?`, 0) {
+			resp, err := helper.GenericJSONPost(section, command, nil)
+			if err != nil {
+				fmt.Println(err)
+				ExitWithError = true
+			} else {
+				ExitWithError = !helper.ShowJSONResponse(resp)
+			}
+		}
+	},
+}
+
+func init() {
+	osDataDiskCmd.AddCommand(osDataDiskWipeCmd)
+}

--- a/cmd/os_datadisk_wipe.go
+++ b/cmd/os_datadisk_wipe.go
@@ -13,15 +13,16 @@ var osDataDiskWipeCmd = &cobra.Command{
 	Aliases: []string{"wipe", "reset", "erase"},
 	Short:   "Wipe the Home Assistant Operating-System data partition",
 	Long: `
-This command will wipe all config for addons and Home Assistant and any locally
-stored data in config, backups, media, etc. The machine will reboot during this.
+This command will wipe all config/settings for addons, Home Assistant and the Operating
+System and any locally stored data in config, backups, media, etc. The machine will
+reboot during this.
 
 After the reboot completes the latest stable version of Home Assistant and Supervisor
 will be downloaded. Once the process is complete you will see onboarding, like
 during initial setup.
 
-The Operating System will not change during this. This includes OS level settings
-such as network settings.
+This wipe also include network settings. So after the reboot you may need to reconfigure
+those in order to access Home Assistant again.
 
 Please note, this command is limited due to security reasons, and will
 only work on some locations. For example, the Operating System CLI.

--- a/cmd/os_datadisk_wipe.go
+++ b/cmd/os_datadisk_wipe.go
@@ -48,6 +48,8 @@ Are you sure you want to proceed?`, 0) {
 			} else {
 				ExitWithError = !helper.ShowJSONResponse(resp)
 			}
+		} else {
+			fmt.Println("Aborted.")
 		}
 	},
 }


### PR DESCRIPTION
Add device wipe command to leverage new API in https://github.com/home-assistant/supervisor/pull/4934

As this command is quite destructive, it requires user confirmation to proceed.