### PR TITLE
Increase timeout for add-on updates

### DIFF
--- a/cmd/addons_update.go
+++ b/cmd/addons_update.go
@@ -37,7 +37,7 @@ It is currently not possible to upgrade/downgrade to a specific version.
 		}
 
 		ProgressSpinner.Start()
-		request := helper.GetJSONRequest()
+		request := helper.GetJSONRequestTimeout(helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 
 		slug := args[0]


### PR DESCRIPTION
Use default container download timeout for add-on updates.

Fixes: #418