### PR TITLE
Use --ipv(4|6)-nameserver as argument consistently

### DIFF
--- a/cmd/network_vlan.go
+++ b/cmd/network_vlan.go
@@ -84,12 +84,12 @@ func init() {
 	networkVlanCmd.Flags().StringArray("ipv4-address", []string{}, "IPv4 address for the interface in the 192.168.1.5/24")
 	networkVlanCmd.Flags().String("ipv4-gateway", "", "The IPv4 gateway the interface should use")
 	networkVlanCmd.Flags().String("ipv4-method", "", "Method on IPv4: static|auto|disabled")
-	networkVlanCmd.Flags().StringArray("ipv4-nameserver", []string{}, "Upstream DNS servers to use for IPv4. Use multiple times for multiple servers.")
+	networkVlanCmd.Flags().StringArray("ipv4-nameserver", []string{}, "IPv4 address of upstream DNS servers. Use multiple times for multiple servers.")
 
 	networkVlanCmd.Flags().StringArray("ipv6-address", []string{}, "IPv6 address for the interface in the 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64")
 	networkVlanCmd.Flags().String("ipv6-gateway", "", "The IPv6 gateway the interface should use")
 	networkVlanCmd.Flags().String("ipv6-method", "", "Method on IPv6: static|auto|disabled")
-	networkVlanCmd.Flags().StringArray("ipv6-nameserver", []string{}, "Upstream DNS servers to use for IPv6. Use multiple times for multiple servers.")
+	networkVlanCmd.Flags().StringArray("ipv6-nameserver", []string{}, "IPv6 address for upstream DNS servers. Use multiple times for multiple servers.")
 
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv4-address", cobra.NoFileCompletions)
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv4-gateway", cobra.NoFileCompletions)


### PR DESCRIPTION
This essentially reverts #445 and fixes it a bit different. First of, the plural is confusing as multiple nameservers can't be passed using the --ipv(4|6)-nameservers argument. Instead, specifying the argument multiple times is the right way to go.

However, the API indeed uses `nameservers` as the key, and that is why the argument change fixes the command in first place.

The Supervisor API is a bit inconsistent here: `address` is a list too, but the key string is a singular. This makes the CLI a bit weird.

Use singular for the string array argument consistently for address and nameserver as it feels more natural.

Also fix the nameserver argument for VLANs.