### PR TITLE
Fix number of lines argument

### DIFF
--- a/cmd/host.go
+++ b/cmd/host.go
@@ -67,9 +67,9 @@ func processLogsFlags(section string, cmd *cobra.Command) (*resty.Request, error
 	/* Disable timeouts to allow following forever */
 	request := client.GetRequestTimeout(0).SetHeader("Accept", accept).SetDoNotParseResponse(true)
 
-	lines, _ := cmd.Flags().GetInt32("lines")
+	lines, _ := cmd.Flags().GetUint32("lines")
 	if lines > 0 {
-		rangeHeader := fmt.Sprintf("entries=:%d:", -(lines - 1))
+		rangeHeader := fmt.Sprintf("entries=:%d:", -(int(lines) - 1))
 		log.WithField("value", rangeHeader).Debug("Range header")
 		request.SetHeader("Range", rangeHeader)
 	}


### PR DESCRIPTION
With #471 the argument type changed to unsigned. This requires also a change when getting the value. We still need to convert the number to a signed integer since we need to pass a negative number as range header (to request the last x number of lines).