### PR TITLE
Fix host logs follow mode with identifier specified

### DIFF
--- a/cmd/host_logs.go
+++ b/cmd/host_logs.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
@@ -36,7 +37,12 @@ across services and boots.
 
 		identifier, _ := cmd.Flags().GetString("identifier")
 		if len(identifier) > 0 {
-			request.URL += "/identifiers/{identifier}"
+			if strings.HasSuffix(request.URL, "/follow") {
+				// We can safely do this because "/follow" will be always at the end
+				request.URL = strings.Replace(request.URL, "/follow", "/identifiers/{identifier}/follow", 1)
+			} else {
+				request.URL += "/identifiers/{identifier}"
+			}
 		}
 		request.SetPathParam("identifier", identifier)
 


### PR DESCRIPTION
'ha host logs -t identifier -f' doesn't work because the identifier is naively appended to the URL, but in that case the "/follow" ends up in the middle of the path. When follow mode is requested, do another naive assumption and replace /follow substring with the correct subpath.

Fixes #492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL construction logic to correctly handle paths ending with "/follow," ensuring proper inclusion of identifiers in the URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->