### PR TITLE
Add force options to commands restricted during migrations

### DIFF
--- a/cmd/core_rebuild.go
+++ b/cmd/core_rebuild.go
@@ -32,6 +32,10 @@ Don't worry, this does not delete your config.`,
 		if err == nil && safeMode {
 			options["safe_mode"] = safeMode
 		}
+		force, err := cmd.Flags().GetBool("force")
+		if err == nil && force {
+			options["force"] = force
+		}
 
 		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPostTimeout(section, command, options, helper.ContainerOperationTimeout)
@@ -47,8 +51,11 @@ Don't worry, this does not delete your config.`,
 
 func init() {
 	coreRebuildCmd.Flags().BoolP("safe-mode", "s", false, "Rebuild Home Assistant in safe mode")
+	coreRebuildCmd.Flags().BoolP("force", "f", false, "Force rebuild during an offline db migration")
 	coreRebuildCmd.Flags().Lookup("safe-mode").NoOptDefVal = "true"
+	coreRebuildCmd.Flags().Lookup("force").NoOptDefVal = "true"
 	coreRebuildCmd.RegisterFlagCompletionFunc("safe-mode", boolCompletions)
+	coreRebuildCmd.RegisterFlagCompletionFunc("force", boolCompletions)
 
 	coreCmd.AddCommand(coreRebuildCmd)
 }

--- a/cmd/core_restart.go
+++ b/cmd/core_restart.go
@@ -30,6 +30,10 @@ Restart the Home Assistant Core instance running on your system`,
 		if err == nil && safeMode {
 			options["safe_mode"] = safeMode
 		}
+		force, err := cmd.Flags().GetBool("force")
+		if err == nil && force {
+			options["force"] = force
+		}
 
 		ProgressSpinner.Start()
 		resp, err := helper.GenericJSONPostTimeout(section, command, options, helper.ContainerOperationTimeout)
@@ -46,8 +50,11 @@ Restart the Home Assistant Core instance running on your system`,
 
 func init() {
 	coreRestartCmd.Flags().BoolP("safe-mode", "s", false, "Restart Home Assistant in safe mode")
+	coreRestartCmd.Flags().BoolP("force", "f", false, "Force restart during an offline db migration")
 	coreRestartCmd.Flags().Lookup("safe-mode").NoOptDefVal = "true"
+	coreRestartCmd.Flags().Lookup("force").NoOptDefVal = "true"
 	coreRestartCmd.RegisterFlagCompletionFunc("safe-mode", boolCompletions)
+	coreRestartCmd.RegisterFlagCompletionFunc("force", boolCompletions)
 
 	coreCmd.AddCommand(coreRestartCmd)
 }

--- a/cmd/core_stop.go
+++ b/cmd/core_stop.go
@@ -25,8 +25,15 @@ your system.`,
 		section := "core"
 		command := "stop"
 
+		options := make(map[string]interface{})
+
+		force, err := cmd.Flags().GetBool("force")
+		if err == nil && force {
+			options["force"] = force
+		}
+
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(section, command, nil, helper.ContainerOperationTimeout)
+		resp, err := helper.GenericJSONPostTimeout(section, command, options, helper.ContainerOperationTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)
@@ -38,5 +45,8 @@ your system.`,
 }
 
 func init() {
+	coreStopCmd.Flags().BoolP("force", "f", false, "Force stop during an offline db migration")
+	coreStopCmd.Flags().Lookup("force").NoOptDefVal = "true"
+	coreStopCmd.RegisterFlagCompletionFunc("force", boolCompletions)
 	coreCmd.AddCommand(coreStopCmd)
 }

--- a/cmd/host_reboot.go
+++ b/cmd/host_reboot.go
@@ -24,7 +24,14 @@ Reboot the machine that your Home Assistant is running on.`,
 		section := "host"
 		command := "reboot"
 
-		resp, err := helper.GenericJSONPost(section, command, nil)
+		options := make(map[string]interface{})
+
+		force, err := cmd.Flags().GetBool("force")
+		if err == nil && force {
+			options["force"] = force
+		}
+
+		resp, err := helper.GenericJSONPost(section, command, options)
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true
@@ -35,5 +42,8 @@ Reboot the machine that your Home Assistant is running on.`,
 }
 
 func init() {
+	hostRebootCmd.Flags().BoolP("force", "f", false, "Force reboot during an offline db migration")
+	hostRebootCmd.Flags().Lookup("force").NoOptDefVal = "true"
+	hostRebootCmd.RegisterFlagCompletionFunc("force", boolCompletions)
 	hostCmd.AddCommand(hostRebootCmd)
 }

--- a/cmd/host_shutdown.go
+++ b/cmd/host_shutdown.go
@@ -25,7 +25,14 @@ WARNING: This is turning off the computer/device.`,
 		section := "host"
 		command := "shutdown"
 
-		resp, err := helper.GenericJSONPost(section, command, nil)
+		options := make(map[string]interface{})
+
+		force, err := cmd.Flags().GetBool("force")
+		if err == nil && force {
+			options["force"] = force
+		}
+
+		resp, err := helper.GenericJSONPost(section, command, options)
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true
@@ -36,5 +43,8 @@ WARNING: This is turning off the computer/device.`,
 }
 
 func init() {
+	hostShutdownCmd.Flags().BoolP("force", "f", false, "Force shutdown during an offline db migration")
+	hostShutdownCmd.Flags().Lookup("force").NoOptDefVal = "true"
+	hostShutdownCmd.RegisterFlagCompletionFunc("force", boolCompletions)
 	hostCmd.AddCommand(hostShutdownCmd)
 }


### PR DESCRIPTION
Add new `force` options added in https://github.com/home-assistant/supervisor/pull/5205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--force` option to several commands (`coreRebuild`, `coreRestart`, `coreStop`, `hostReboot`, `hostShutdown`), allowing users to enforce actions during offline database migrations.
  
- **Usability Improvements**
  - Enhanced command-line interface with shorthand flags and default values for improved user control and experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->