### PR TITLE
Centralize error handling and add 503 support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -24,7 +23,7 @@ func GenericJSONErrorHandling(resp *resty.Response, err error) (*resty.Response,
 		}
 
 		if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-			err = errors.New("API did not return a JSON response")
+			err = fmt.Errorf("API did not return a JSON response. Status code %d", resp.StatusCode())
 			log.Error(err)
 			return nil, err
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -14,11 +14,16 @@ var RawJSON = false
 
 func GenericJSONErrorHandling(resp *resty.Response, err error) (*resty.Response, error) {
 	if err == nil {
-		if resp.StatusCode() != 200 && resp.StatusCode() != 400 && resp.StatusCode() != 503 {
+		switch resp.StatusCode() {
+		case 200, 400, 403, 503:
+			break
+		default:
 			err = fmt.Errorf("Unexpected server response. Status code: %d", resp.StatusCode())
 			log.Error(err)
 			return nil, err
-		} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
+		}
+
+		if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
 			err = errors.New("API did not return a JSON response")
 			log.Error(err)
 			return nil, err

--- a/cmd/addons_info.go
+++ b/cmd/addons_info.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,17 +49,7 @@ is provided, information about a specific add-on.
 		})
 
 		resp, err := request.Get(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/addons_install.go
+++ b/cmd/addons_install.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -47,16 +46,7 @@ This command allows you to install a Home Assistant add-on from the commandline.
 		resp, err := request.Post(url)
 		ProgressSpinner.Stop()
 
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/addons_rebuild.go
+++ b/cmd/addons_rebuild.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,16 +49,7 @@ add-on.
 		resp, err := request.Post(url)
 		ProgressSpinner.Stop()
 
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/addons_restart.go
+++ b/cmd/addons_restart.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,17 +43,7 @@ Restart a Home Assistant add-on
 		})
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/addons_start.go
+++ b/cmd/addons_start.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,17 +43,7 @@ This command allows you to manually start a stopped Home Assistant add-on
 		})
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/addons_stats.go
+++ b/cmd/addons_stats.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -46,17 +45,7 @@ how much CPU, memory, disk & network resources it uses.
 		})
 
 		resp, err := request.Get(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/addons_stop.go
+++ b/cmd/addons_stop.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,17 +43,7 @@ This command allows you to manually start a stopped Home Assistant add-on
 		})
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/addons_uninstall.go
+++ b/cmd/addons_uninstall.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,17 +51,7 @@ This command allows you to uninstall a Home Assistant add-on.
 		}
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/addons_update.go
+++ b/cmd/addons_update.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -60,17 +59,7 @@ It is currently not possible to upgrade/downgrade to a specific version.
 		}
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/auth_cache.go
+++ b/cmd/auth_cache.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,17 +37,7 @@ This command allows you to reset the internal password cache of a Home Assistant
 		request := helper.GetJSONRequest()
 
 		resp, err := request.Delete(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/backups_info.go
+++ b/cmd/backups_info.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,17 +43,7 @@ This command gives you information about a specific backup.`,
 		})
 
 		resp, err := request.Get(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/backups_remove.go
+++ b/cmd/backups_remove.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -43,17 +42,7 @@ clean backups from disk.`,
 		})
 
 		resp, err := request.Delete(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/backups_restore.go
+++ b/cmd/backups_restore.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -81,16 +80,7 @@ take Home Assistant backup on your system.`,
 		resp, err := request.Post(url)
 		ProgressSpinner.Stop()
 
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/docker_registries_add.go
+++ b/cmd/docker_registries_add.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -58,17 +57,7 @@ Add new login for the Docker OCI registry server.
 		}
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/docker_registries_delete.go
+++ b/cmd/docker_registries_delete.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,17 +43,7 @@ Remove login for the Docker OCI registry server.
 		})
 
 		resp, err := request.Delete(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/mounts_add.go
+++ b/cmd/mounts_add.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -49,17 +48,7 @@ Add and configure a new mount in Supervisor.
 		}
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/mounts_delete.go
+++ b/cmd/mounts_delete.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -43,17 +42,7 @@ Unmount and delete an existing mount from Supervisor.
 		})
 
 		resp, err := request.Delete(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/mounts_reload.go
+++ b/cmd/mounts_reload.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,17 +43,7 @@ the same configuration.
 		})
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/mounts_update.go
+++ b/cmd/mounts_update.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -51,17 +50,7 @@ Update or change the configuration of an existing mount in Supervisor.
 		}
 
 		resp, err := request.Put(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/network_scan.go
+++ b/cmd/network_scan.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -48,16 +47,7 @@ This function works only on a wireless interface!
 		resp, err := request.Get(url)
 		ProgressSpinner.Stop()
 
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/network_update.go
+++ b/cmd/network_update.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -61,17 +60,7 @@ Update network interface settings of a specific adapter.
 		request.SetBody(options)
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/network_vlan.go
+++ b/cmd/network_vlan.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -58,17 +57,7 @@ This function works only on an ethernet interface!
 		}
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/resolution_check_options.go
+++ b/cmd/resolution_check_options.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,17 +51,7 @@ This command allows to apply options to an specific check managed by the system.
 			request.SetBody(options)
 		}
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/resolution_check_run.go
+++ b/cmd/resolution_check_run.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -45,16 +44,7 @@ This command executes an backend check immediately on the system.`,
 		resp, err := request.Post(url)
 		ProgressSpinner.Stop()
 
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/resolution_issue_dismiss.go
+++ b/cmd/resolution_issue_dismiss.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,17 +41,7 @@ This command allows dismissing issues reported by the system.`,
 		})
 
 		resp, err := request.Delete(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/resolution_issue_suggestions.go
+++ b/cmd/resolution_issue_suggestions.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,17 +41,7 @@ This command returns suggestions which resolve an issue when applied.`,
 		})
 
 		resp, err := request.Get(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/resolution_suggestion_apply.go
+++ b/cmd/resolution_suggestion_apply.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,17 +41,7 @@ This command allow to apply an suggestion reported by the System.`,
 		})
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/resolution_suggestion_dismiss.go
+++ b/cmd/resolution_suggestion_dismiss.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,17 +41,7 @@ This command allows dismissing a suggestion reported by the system.`,
 		})
 
 		resp, err := request.Delete(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/store_addons_install.go
+++ b/cmd/store_addons_install.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -47,16 +46,7 @@ This command allows you to install a Home Assistant add-on from the commandline.
 		resp, err := request.Post(url)
 		ProgressSpinner.Stop()
 
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/store_addons_update.go
+++ b/cmd/store_addons_update.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -60,17 +59,7 @@ It is currently not possible to upgrade/downgrade to a specific version.
 		}
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("Unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/store_repositories_add.go
+++ b/cmd/store_repositories_add.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -48,17 +47,7 @@ ha store add https://github.com/home-assistant/addons-example
 		}
 
 		resp, err := request.Post(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/store_repositories_delete.go
+++ b/cmd/store_repositories_delete.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
-	resty "github.com/go-resty/resty/v2"
+	"github.com/home-assistant/cli/client"
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,17 +43,7 @@ ha store delete 94cfad5a
 		})
 
 		resp, err := request.Delete(url)
-
-		// returns 200 OK or 400, everything else is wrong
-		if err == nil {
-			if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-				err = errors.New("unexpected server response")
-				log.Error(err)
-			} else if !resty.IsJSONType(resp.Header().Get("Content-Type")) {
-				err = errors.New("API did not return a JSON response")
-				log.Error(err)
-			}
-		}
+		resp, err = client.GenericJSONErrorHandling(resp, err)
 
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
Supervisor may return a 503 now to denote that a service it depends on for a particular API call is temporarily unavailable (see https://github.com/home-assistant/supervisor/pull/5205 ). CLI should print the message it receives from supervisor explaining the situation and not "unknown error".

Adding this support required first centralizing error handling as it was copied and pasted all over, hence the larger then expected PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced centralized error handling for HTTP responses to improve maintainability and readability across multiple commands.
  
- **Bug Fixes**
	- Enhanced error handling for various commands by replacing manual checks with a dedicated function, reducing errors related to response management.

- **Refactor**
	- Streamlined error handling processes in numerous files, consolidating logic to improve code organization and maintainability.

- **Chores**
	- Updated code to enhance modularity and simplify the control flow within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->