### PR TITLE
Use string formatting for final spinner message

### DIFF
--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -133,7 +133,7 @@ func (s *Spinner) Stop() {
 		s.active = false
 		s.erase()
 		if s.FinalMSG != "" {
-			fmt.Fprintf(s.Writer, s.FinalMSG)
+			fmt.Fprintf(s.Writer, "%s", s.FinalMSG)
 		}
 		s.stopChan <- struct{}{}
 	}


### PR DESCRIPTION
Make sure that the final message is not interpreted as string formatting but really as a string. This fixes an error uncovered by the codespell upgrade (see #507).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the formatting of final messages displayed when stopping the spinner, ensuring clearer and safer output.

- **Documentation**
	- Enhanced clarity in the output of spinner messages, contributing to better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->