### PR TITLE
Increase ha supervisor repair timeout to 1h

### DIFF
--- a/cmd/supervisor_repair.go
+++ b/cmd/supervisor_repair.go
@@ -28,7 +28,7 @@ the Home Assistant Supervisor will try to resolve these.
 		command := "repair"
 
 		ProgressSpinner.Start()
-		resp, err := helper.GenericJSONPostTimeout(section, command, nil, helper.ContainerOperationTimeout)
+		resp, err := helper.GenericJSONPostTimeout(section, command, nil, helper.ContainerDownloadTimeout)
 		ProgressSpinner.Stop()
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
This command potentially downloads containers. Use the default container download timeout of 1h.

Fixes: https://github.com/home-assistant/supervisor/issues/5627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the timeout for repair operations, ensuring the system waits an appropriate duration for responses during repair attempts. This update helps improve reliability by reducing the chance of premature timeouts during supervisor repairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->