### PR TITLE
Add `ha os config swap` command set

### DIFF
--- a/cmd/os_config.go
+++ b/cmd/os_config.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var osConfigCmd = &cobra.Command{
+	Use:     "config",
+	Aliases: []string{"conf", "cfg"},
+	Short:   "Show or change Home Assistant OS settings",
+	Long: `
+This command allows you to show or change settings of Home Assistant OS.`,
+	Example: `
+  ha os config swap`,
+}
+
+func init() {
+	osCmd.AddCommand(osConfigCmd)
+}

--- a/cmd/os_config_swap.go
+++ b/cmd/os_config_swap.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var osConfigSwapCmd = &cobra.Command{
+	Use:     "swap",
+	Aliases: []string{"sw"},
+	Short:   "Show or change Home Assistant OS swap settings",
+	Long: `
+This command allows you to show or change current swap configuration
+of Home Assistant OS.`,
+	Example: `
+  ha os config swap info`,
+}
+
+func init() {
+	osConfigCmd.AddCommand(osConfigSwapCmd)
+}

--- a/cmd/os_config_swap_info.go
+++ b/cmd/os_config_swap_info.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var osConfigSwapInfoCmd = &cobra.Command{
+	Use:     "info",
+	Aliases: []string{"in", "info"},
+	Short:   "Show HAOS swap settings",
+	Long: `
+This command allows you to see how swap is used by the Home Assistant OS.`,
+	Example: `
+  ha os config swap info`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("os config swap info")
+
+		section := "os"
+		command := "config/swap"
+
+		resp, err := helper.GenericJSONGet(section, command)
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	osConfigSwapCmd.AddCommand(osConfigSwapInfoCmd)
+}

--- a/cmd/os_config_swap_options.go
+++ b/cmd/os_config_swap_options.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var osConfigSwapOptionsCmd = &cobra.Command{
+	Use:     "options",
+	Aliases: []string{"option", "opt", "opts", "op"},
+	Short:   "Change HAOS swap settings",
+	Long: `
+This command allows you to override how the Home Assistant OS uses swap.`,
+	Example: `
+  ha os config swap options --swap-size=2G --swappiness=10`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("os config swap options")
+
+		section := "os"
+		command := "config/swap"
+
+		options := make(map[string]any)
+
+		swapSize, err := cmd.Flags().GetString("swap-size")
+		if err == nil && cmd.Flags().Changed("swap-size") {
+			options["swap_size"] = swapSize
+		}
+
+		swappiness, err := cmd.Flags().GetInt("swappiness")
+		if err == nil && cmd.Flags().Changed("swappiness") {
+			options["swappiness"] = swappiness
+		}
+
+		resp, err := helper.GenericJSONPost(section, command, options)
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	osConfigSwapOptionsCmd.Flags().String("swap-size", "", "Swap size in bytes with optional units (K/M/G)")
+	osConfigSwapOptionsCmd.Flags().Int("swappiness", 1, "Kernel swappiness value (0-200)")
+
+	osConfigSwapCmd.AddCommand(osConfigSwapOptionsCmd)
+}


### PR DESCRIPTION
Add commands interfacing with the swap API added in home-assistant/supervisor#5770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new CLI command for configuring Home Assistant OS settings with user-friendly aliases.
	- Introduced a swap management suite allowing users to view swap details, retrieve informative swap insights, and modify swap settings with configurable options for swap size and swappiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->