### PR TITLE
Increase timeout for operations requiring reboot to 90s

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -23,6 +23,7 @@ const ContainerOperationTimeout = 10 * time.Minute
 const ContainerDownloadTimeout = 1 * time.Hour
 const OsDownloadTimeout = 1 * time.Hour
 const BackupTimeout = 3 * time.Hour
+const RebootTimeout = 90 * time.Second
 
 var client *resty.Client
 

--- a/cmd/host_reboot.go
+++ b/cmd/host_reboot.go
@@ -31,7 +31,7 @@ Reboot the machine that your Home Assistant is running on.`,
 			options["force"] = force
 		}
 
-		resp, err := helper.GenericJSONPost(section, command, options)
+		resp, err := helper.GenericJSONPostTimeout(section, command, options, helper.RebootTimeout)
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/host_shutdown.go
+++ b/cmd/host_shutdown.go
@@ -32,7 +32,7 @@ WARNING: This is turning off the computer/device.`,
 			options["force"] = force
 		}
 
-		resp, err := helper.GenericJSONPost(section, command, options)
+		resp, err := helper.GenericJSONPostTimeout(section, command, options, helper.RebootTimeout)
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true

--- a/cmd/os_boot_slot.go
+++ b/cmd/os_boot_slot.go
@@ -58,7 +58,7 @@ an OS update without making more changes to the system.
 		}
 
 		options := map[string]any{"boot_slot": bootSlot}
-		resp, err := helper.GenericJSONPost(section, command, options)
+		resp, err := helper.GenericJSONPostTimeout(section, command, options, helper.RebootTimeout)
 		if err != nil {
 			fmt.Println(err)
 			ExitWithError = true


### PR DESCRIPTION
Users are sometimes confused when they try to reboot or switch slots and the operation fails with the generic error, while it's been already submitted and is performed shortly after. Allow more time for the operation to finish gracefully, as terminating it while it's been posted usually wouldn't cancel it anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Critical host operations—including reboot, shutdown, and OS boot slot selection—now enforce a 90-second timeout, reducing delays during network requests.
- **Refactor**
  - Adjusted the underlying request handling to integrate timeout management, enhancing overall system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->