### PR TITLE
Align handling of EOF in interactive prompts

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -196,7 +196,7 @@ func StreamTextResponse(resp *resty.Response) (success bool) {
 	return
 }
 
-func AskForConfirmation(prompt string, tries int) bool {
+func AskForConfirmation(prompt string, tries int) (bool, error) {
 	reader := bufio.NewReader(os.Stdin)
 	if tries <= 0 {
 		tries = 2
@@ -207,22 +207,22 @@ func AskForConfirmation(prompt string, tries int) bool {
 
 		res, err := reader.ReadString('\n')
 		if err != nil {
-			log.Fatalf("error: %v", err)
-			continue
+			fmt.Println()
+			return false, err
 		}
 
 		// Require YES or yes explicitly to confirm
 		res = strings.ToLower(strings.TrimSpace(res))
 		if res == "yes" {
-			return true
+			return true, nil
 		}
 
 		// If user enters no or n then stop. Else retry since they entered something unknown
 		if len(res) > 0 && res[0] == 'n' {
-			return false
+			return false, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func ReadInteger(prompt string, tries int, min int, max int) (int, error) {
@@ -236,8 +236,8 @@ func ReadInteger(prompt string, tries int, min int, max int) (int, error) {
 
 		res, err := reader.ReadString('\n')
 		if err != nil {
-			log.Fatalf("error: %v", err)
-			continue
+			fmt.Println()
+			return 0, err
 		}
 
 		res = strings.TrimSpace(res)

--- a/cmd/auth_reset.go
+++ b/cmd/auth_reset.go
@@ -114,7 +114,7 @@ only work on some locations. For example, the Operating System CLI.
 
 				idx, err := helper.ReadInteger("Select a user to reset the password for", 3, 1, len(users))
 				if err != nil {
-					fmt.Println("Aborted: ", err)
+					cmd.PrintErrln("Aborted:", err)
 					ExitWithError = true
 					return
 				}

--- a/cmd/os_datadisk_wipe.go
+++ b/cmd/os_datadisk_wipe.go
@@ -38,9 +38,17 @@ only work on some locations. For example, the Operating System CLI.
 		section := "os"
 		command := "datadisk/wipe"
 
-		if helper.AskForConfirmation(`
+		confirmed, err := helper.AskForConfirmation(`
 This will completely wipe the datadisk. This process is irreversible.
-Are you sure you want to proceed?`, 0) {
+Are you sure you want to proceed?`, 0)
+
+		if err != nil {
+			cmd.PrintErrln("Aborted:", err)
+			ExitWithError = true
+			return
+		}
+
+		if confirmed {
 			resp, err := helper.GenericJSONPost(section, command, nil)
 			if err != nil {
 				fmt.Println(err)
@@ -49,7 +57,8 @@ Are you sure you want to proceed?`, 0) {
 				ExitWithError = !helper.ShowJSONResponse(resp)
 			}
 		} else {
-			fmt.Println("Aborted.")
+			cmd.PrintErrln("Aborted.")
+			ExitWithError = true
 		}
 	},
 }


### PR DESCRIPTION
As discussed in review of #558, handling of errors (e.g. EOF) when reading the input from users could be better. All commands that read input from users now exit with non-zero status code when the operation is aborted and print the message to error out instead of logging it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting and messaging during interactive prompts, including those for password reset and data wipe operations.
  - Enhanced handling of invalid input with clear, immediate feedback, ensuring users are better informed of issues.

- **Refactor**
  - Updated core interactions to return more detailed feedback, increasing overall robustness and clarity in user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->