### PR TITLE
Show error on auth reset with no users configured

### DIFF
--- a/cmd/auth_reset.go
+++ b/cmd/auth_reset.go
@@ -109,6 +109,12 @@ only work on some locations. For example, the Operating System CLI.
 					return
 				}
 
+				if len(users) == 0 {
+					cmd.PrintErrln("No users configured.")
+					ExitWithError = true
+					return
+				}
+
 				fmt.Println("List of users:")
 				listUsers(users)
 


### PR DESCRIPTION
Reset on a fresh install shows a rather confusing message:

  List of users:
  Select a user to reset the password for [1-0]:

When the list is empty, just print an error and quit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the account reset process so that if no user accounts are configured, a clear error message is displayed and further processing is halted. This update ensures that users receive immediate, actionable feedback, enhancing the overall reliability and user experience of the command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->