### PR TITLE
Add `--ipv6-addr-gen-mode` and `--ipv6-privacy` options for `ha network`

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -28,6 +28,14 @@ func ipMethodCompletions(cmd *cobra.Command, args []string, toComplete string) (
 	return []string{"static", "auto", "disabled"}, cobra.ShellCompDirectiveNoFileComp
 }
 
+func ipAddrGenModeCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"eui64", "stable-privacy", "default-or-eui64", "default"}, cobra.ShellCompDirectiveNoFileComp
+}
+
+func ip6PrivacyCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"disabled", "enabled-prefer-public", "enabled", "default"}, cobra.ShellCompDirectiveNoFileComp
+}
+
 func networkInterfaceCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) != 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/network_update.go
+++ b/cmd/network_update.go
@@ -80,6 +80,8 @@ func init() {
 	networkUpdateCmd.Flags().StringArray("ipv6-address", []string{}, "IPv6 address for the interface in the 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64")
 	networkUpdateCmd.Flags().String("ipv6-gateway", "", "The IPv6 gateway the interface should use")
 	networkUpdateCmd.Flags().String("ipv6-method", "", "Method on IPv6: static|auto|disabled")
+	networkUpdateCmd.Flags().String("ipv6-addr-gen-mode", "", "IPv6 address generation mode: eui64|stable-privacy")
+	networkUpdateCmd.Flags().String("ipv6-privacy", "", "IPv6 privacy extensions: disabled|enabled-prefer-public|enabled")
 	networkUpdateCmd.Flags().StringArray("ipv6-nameserver", []string{}, "IPv6 address for upstream DNS servers. Use multiple times for multiple servers.")
 
 	networkUpdateCmd.Flags().String("wifi-mode", "", "Wifi mode: infrastructure, adhoc, mesh or ap")
@@ -97,6 +99,8 @@ func init() {
 	networkUpdateCmd.RegisterFlagCompletionFunc("ipv6-address", cobra.NoFileCompletions)
 	networkUpdateCmd.RegisterFlagCompletionFunc("ipv6-gateway", cobra.NoFileCompletions)
 	networkUpdateCmd.RegisterFlagCompletionFunc("ipv6-method", ipMethodCompletions)
+	networkUpdateCmd.RegisterFlagCompletionFunc("ipv6-addr-gen-mode", ipAddrGenModeCompletions)
+	networkUpdateCmd.RegisterFlagCompletionFunc("ipv6-privacy", ip6PrivacyCompletions)
 	networkUpdateCmd.RegisterFlagCompletionFunc("ipv6-nameservers", cobra.NoFileCompletions)
 
 	networkUpdateCmd.RegisterFlagCompletionFunc("wifi-mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -145,6 +149,8 @@ func helperIpConfig(version string, cmd *cobra.Command, options map[string]any) 
 	args := []NetworkArg{
 		{Arg: version + "-gateway", ApiKey: "gateway"},
 		{Arg: version + "-method", ApiKey: "method"},
+		{Arg: version + "-addr-gen-mode", ApiKey: "addr_gen_mode"},
+		{Arg: version + "-privacy", ApiKey: "ip6_privacy"},
 		{Arg: version + "-address", ApiKey: "address", IsArray: true},
 		{Arg: version + "-nameserver", ApiKey: "nameservers", IsArray: true},
 	}

--- a/cmd/network_vlan.go
+++ b/cmd/network_vlan.go
@@ -77,6 +77,8 @@ func init() {
 	networkVlanCmd.Flags().StringArray("ipv6-address", []string{}, "IPv6 address for the interface in the 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64")
 	networkVlanCmd.Flags().String("ipv6-gateway", "", "The IPv6 gateway the interface should use")
 	networkVlanCmd.Flags().String("ipv6-method", "", "Method on IPv6: static|auto|disabled")
+	networkVlanCmd.Flags().String("ipv6-addr-gen-mode", "", "IPv6 address generation mode: eui64|stable-privacy")
+	networkVlanCmd.Flags().String("ipv6-privacy", "", "IPv6 privacy extensions: disabled|enabled-prefer-public|enabled")
 	networkVlanCmd.Flags().StringArray("ipv6-nameserver", []string{}, "IPv6 address for upstream DNS servers. Use multiple times for multiple servers.")
 
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv4-address", cobra.NoFileCompletions)
@@ -87,6 +89,8 @@ func init() {
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-address", cobra.NoFileCompletions)
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-gateway", cobra.NoFileCompletions)
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-method", ipMethodCompletions)
+	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-addr-gen-mode", ipAddrGenModeCompletions)
+	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-privacy", ip6PrivacyCompletions)
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-nameserver", cobra.NoFileCompletions)
 
 	networkCmd.AddCommand(networkVlanCmd)

--- a/cmd/network_vlan.go
+++ b/cmd/network_vlan.go
@@ -77,7 +77,7 @@ func init() {
 	networkVlanCmd.Flags().StringArray("ipv6-address", []string{}, "IPv6 address for the interface in the 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64")
 	networkVlanCmd.Flags().String("ipv6-gateway", "", "The IPv6 gateway the interface should use")
 	networkVlanCmd.Flags().String("ipv6-method", "", "Method on IPv6: static|auto|disabled")
-	networkVlanCmd.Flags().String("ipv6-addr-gen-mode", "", "IPv6 address generation mode: eui64|stable-privacy")
+	networkVlanCmd.Flags().String("ipv6-addr-gen-mode", "", "IPv6 address generation mode: eui64|stable-privacy|default-or-eui64|default")
 	networkVlanCmd.Flags().String("ipv6-privacy", "", "IPv6 privacy extensions: disabled|enabled-prefer-public|enabled")
 	networkVlanCmd.Flags().StringArray("ipv6-nameserver", []string{}, "IPv6 address for upstream DNS servers. Use multiple times for multiple servers.")
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add options to modify address generation mode and privacy extensions for `ha network update & vlan`.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/supervisor/pull/5892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added new IPv6 configuration options to network update and VLAN commands: "ipv6-addr-gen-mode" and "ipv6-privacy".
  - Introduced command-line completion support for these new IPv6 flags, making it easier to select valid values when using the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->