### PR TITLE
Fix 'docker options' example syntax

### DIFF
--- a/cmd/docker_options.go
+++ b/cmd/docker_options.go
@@ -18,7 +18,7 @@ var dockerOptionsCmd = &cobra.Command{
 This command allows you to set configuration options for on the host
 docker backend running on your Home Assistant system.`,
 	Example: `
-  ha docker options --enable-ipv6 true`,
+  ha docker options --enable-ipv6=true`,
 	ValidArgsFunction: cobra.NoFileCompletions,
 	Args:              cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
The example given for the new docker options command contains invalid syntax, as the boolean flag requires "=" separator in order to be parsed correctly, otherwise the following error is shown:

Error while executing rootCmd: unknown command "true" for "ha docker options"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example usage in the command help to display flag values using an equals sign (e.g., --enable-ipv6=true) for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->