### PR TITLE
Clarify help text for ha network update/vlan addresses

### DIFF
--- a/cmd/network_update.go
+++ b/cmd/network_update.go
@@ -77,7 +77,7 @@ func init() {
 	networkUpdateCmd.Flags().String("ipv4-method", "", "Method on IPv4: static|auto|disabled")
 	networkUpdateCmd.Flags().StringArray("ipv4-nameserver", []string{}, "IPv4 address of upstream DNS servers. Use multiple times for multiple servers.")
 
-	networkUpdateCmd.Flags().StringArray("ipv6-address", []string{}, "IPv6 address for the interface in CIDR notation (e.g. 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64)")
+	networkUpdateCmd.Flags().StringArray("ipv6-address", []string{}, "IPv6 address for the interface in CIDR notation (e.g. 2001:db8:85a3::8a2e:370:7334/64)")
 	networkUpdateCmd.Flags().String("ipv6-gateway", "", "The IPv6 gateway the interface should use")
 	networkUpdateCmd.Flags().String("ipv6-method", "", "Method on IPv6: static|auto|disabled")
 	networkUpdateCmd.Flags().String("ipv6-addr-gen-mode", "", "IPv6 address generation mode: eui64|stable-privacy|default-or-eui64|default")

--- a/cmd/network_vlan.go
+++ b/cmd/network_vlan.go
@@ -74,7 +74,7 @@ func init() {
 	networkVlanCmd.Flags().String("ipv4-method", "", "Method on IPv4: static|auto|disabled")
 	networkVlanCmd.Flags().StringArray("ipv4-nameserver", []string{}, "IPv4 address of upstream DNS servers. Use multiple times for multiple servers.")
 
-	networkVlanCmd.Flags().StringArray("ipv6-address", []string{}, "IPv6 address for the interface in CIDR notation (e.g. 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64)")
+	networkVlanCmd.Flags().StringArray("ipv6-address", []string{}, "IPv6 address for the interface in CIDR notation (e.g. 2001:db8:85a3::8a2e:370:7334/64)")
 	networkVlanCmd.Flags().String("ipv6-gateway", "", "The IPv6 gateway the interface should use")
 	networkVlanCmd.Flags().String("ipv6-method", "", "Method on IPv6: static|auto|disabled")
 	networkVlanCmd.Flags().String("ipv6-addr-gen-mode", "", "IPv6 address generation mode: eui64|stable-privacy|default-or-eui64|default")


### PR DESCRIPTION
The help text for addresses in ha network commands was badly worded, probably missing the "format" word. State it takes the "CIDR notation" and use the former example in parenthesis.

Fixes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved help text for IPv4 and IPv6 address flags to clarify that addresses must be provided in CIDR notation, with explicit examples included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->