### PR TITLE
Fix listing active interfaces w/o any address

### DIFF
--- a/cmd/banner.go
+++ b/cmd/banner.go
@@ -121,7 +121,12 @@ var bannerCmd = &cobra.Command{
 					fmt.Printf("  %-25s (No address)\n", title_ipv4)
 				} else {
 					ipv4 := nf["ipv4"].(map[string]any)
-					fmt.Printf("  %-25s %s\n", title_ipv4, getAddresses(ipv4["address"].([]any)))
+					ipv4_addresses := ipv4["address"].([]any)
+					if len(ipv4_addresses) > 0 {
+						fmt.Printf("  %-25s %s\n", title_ipv4, getAddresses(ipv4_addresses))
+					} else {
+						fmt.Printf("  %-25s (No address)\n", title_ipv4)
+					}
 				}
 
 				if nf["ipv6"] != nil {


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix listing active interfaces and their respective addresses to show **(No Address)** if no address is configured. For cases like VLAN parent interface etc.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
