### PR TITLE
Print hint that restart is required if enable-ipv6 flag is passed

### DIFF
--- a/cmd/docker_options.go
+++ b/cmd/docker_options.go
@@ -43,6 +43,9 @@ docker backend running on your Home Assistant system.`,
 			fmt.Println(err)
 			ExitWithError = true
 		} else {
+			if cmd.Flags().Changed("enable-ipv6") {
+				fmt.Println("Note: System restart required to apply new IPv6 configuration.")
+			}
 			ExitWithError = !helper.ShowJSONResponse(resp)
 		}
 	},


### PR DESCRIPTION
Supervisor needs to recreate the Docker hassio network, which it only can do safely when no add-ons are running. Hence a complete OS restart is required to apply the IPv6 change. Print a note about this.

/cc @davidrapan 