### PR TITLE
Add nvme status command

### DIFF
--- a/cmd/host_nvme.go
+++ b/cmd/host_nvme.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var hostNvmeCmd = &cobra.Command{
+	Use:   "nvme",
+	Short: "Manage NVMe devices available on the host system",
+	Long: `
+Show information about or manage NVMe devices available on the host system.`,
+	Example: `
+  ha host nvme status /dev/nvme0n1`,
+}
+
+func init() {
+	hostCmd.AddCommand(hostNvmeCmd)
+}

--- a/cmd/host_nvme.go
+++ b/cmd/host_nvme.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"strings"
+
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -15,4 +19,41 @@ Show information about or manage NVMe devices available on the host system.`,
 
 func init() {
 	hostCmd.AddCommand(hostNvmeCmd)
+}
+
+func nvmeDeviceCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	resp, err := helper.GenericJSONGet("host", "info")
+	if err != nil || !resp.IsSuccess() {
+		log.WithError(err).Debug("Failed to fetch host info for NVMe completion")
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var ret []string
+	data := resp.Result().(*helper.Response)
+	if data.Result == "ok" && data.Data["nvme_devices"] != nil {
+		if devices, ok := data.Data["nvme_devices"].([]any); ok {
+			for _, dev := range devices {
+				var m map[string]any
+				if m, ok = dev.(map[string]any); !ok {
+					continue
+				}
+				var id string
+				if id, ok = m["id"].(string); !ok || id == "" {
+					continue
+				}
+
+				entry := id
+				var path string
+				if path, ok = m["path"].(string); ok && path != "" {
+					entry += "\t" + path
+				}
+				if toComplete == "" || strings.HasPrefix(id, toComplete) {
+					ret = append(ret, entry)
+				}
+			}
+		}
+	}
+	return ret, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/host_nvme_status.go
+++ b/cmd/host_nvme_status.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func nvmeDeviceCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	resp, err := helper.GenericJSONGet("host", "info")
+	if err != nil || !resp.IsSuccess() {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var ret []string
+	data := resp.Result().(*helper.Response)
+	if data.Result == "ok" && data.Data["nvme_devices"] != nil {
+		if devices, ok := data.Data["nvme_devices"].([]any); ok {
+			for _, dev := range devices {
+				var m map[string]any
+				if m, ok = dev.(map[string]any); !ok {
+					continue
+				}
+				id, _ := m["id"].(string)
+				path, _ := m["path"].(string)
+				if id == "" {
+					continue
+				}
+				entry := id
+				if path != "" {
+					entry += "\t" + path
+				}
+				if toComplete == "" || strings.HasPrefix(id, toComplete) {
+					ret = append(ret, entry)
+				}
+			}
+		}
+	}
+	return ret, cobra.ShellCompDirectiveNoFileComp
+}
+
+var hostNvmeStatusCmd = &cobra.Command{
+	Use:   "status [device]",
+	Short: "Show NVMe status for a device",
+	Long: `
+Show NVMe status for a specific device or for the currrent datadisk (if using
+Home Assistant Operating System and the current datadisk is an NVMe device).
+`,
+	Example: `
+  ha host nvme status
+  ha host nvme status /dev/nvme0n1
+`,
+	ValidArgsFunction: nvmeDeviceCompletions,
+	Args:              cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("host nvme status")
+
+		section := "host"
+		command := "nvme/status"
+		if len(args) > 0 {
+			device := url.PathEscape(args[0])
+			command = fmt.Sprintf("nvme/%s/status", device)
+		}
+
+		resp, err := helper.GenericJSONGet(section, command)
+		if err != nil {
+			fmt.Println(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	hostNvmeCmd.AddCommand(hostNvmeStatusCmd)
+}

--- a/cmd/host_nvme_status.go
+++ b/cmd/host_nvme_status.go
@@ -49,7 +49,7 @@ var hostNvmeStatusCmd = &cobra.Command{
 	Use:   "status [device]",
 	Short: "Show NVMe status for a device",
 	Long: `
-Show NVMe status for a specific device or for the currrent datadisk (if using
+Show NVMe status for a specific device or for the current datadisk (if using
 Home Assistant Operating System and the current datadisk is an NVMe device).
 `,
 	Example: `

--- a/cmd/host_nvme_status.go
+++ b/cmd/host_nvme_status.go
@@ -3,47 +3,11 @@ package cmd
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	helper "github.com/home-assistant/cli/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
-
-func nvmeDeviceCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) != 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	resp, err := helper.GenericJSONGet("host", "info")
-	if err != nil || !resp.IsSuccess() {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	var ret []string
-	data := resp.Result().(*helper.Response)
-	if data.Result == "ok" && data.Data["nvme_devices"] != nil {
-		if devices, ok := data.Data["nvme_devices"].([]any); ok {
-			for _, dev := range devices {
-				var m map[string]any
-				if m, ok = dev.(map[string]any); !ok {
-					continue
-				}
-				id, _ := m["id"].(string)
-				path, _ := m["path"].(string)
-				if id == "" {
-					continue
-				}
-				entry := id
-				if path != "" {
-					entry += "\t" + path
-				}
-				if toComplete == "" || strings.HasPrefix(id, toComplete) {
-					ret = append(ret, entry)
-				}
-			}
-		}
-	}
-	return ret, cobra.ShellCompDirectiveNoFileComp
-}
 
 var hostNvmeStatusCmd = &cobra.Command{
 	Use:   "status [device]",


### PR DESCRIPTION
Add support for `ha host nvme status [device]` command to match API added in https://github.com/home-assistant/supervisor/pull/6035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new CLI command to manage NVMe devices under the host command group.
  * Added the ability to check the status of NVMe devices, including support for querying a specific device or the current datadisk if it is an NVMe device.
  * Implemented device name auto-completion for improved command-line usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->