### PR TITLE
Wait longer for Supervisor startup and allow interrupt

### DIFF
--- a/cmd/banner.go
+++ b/cmd/banner.go
@@ -178,6 +178,7 @@ var bannerCmd = &cobra.Command{
 		// Print Host URL
 		hostinfo, err := supervisorGet("host", "info")
 		if err != nil {
+			ExitWithError = true
 			fmt.Printf("  Host information unavailable: %s\n", err)
 			return
 		}
@@ -187,6 +188,7 @@ var bannerCmd = &cobra.Command{
 
 		coreinfo, err := supervisorGet("core", "info")
 		if err != nil {
+			ExitWithError = true
 			fmt.Printf("  Core information unavailable: %s\n", err)
 			return
 		}


### PR DESCRIPTION
Instead of waiting just 60 seconds wait up to 3 minutes for the Supervisor to startup. Also allow the user to interrupt, and write what is happening in case of a timeout and when the Supervisor finished starting up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive startup wait with on-screen prompt and 3-minute timeout.
  * Cancellable wait via keyboard input.
* **Refactor**
  * Reworked startup flow to poll for readiness and proceed immediately on success.
  * Streamlined sequencing so system information is shown after startup readiness.
* **Bug Fixes**
  * More robust display of network, host, and core information with safe fallbacks.
  * Conditional printing of URLs only when data is available.
  * Clearer, user-friendly error messages when information cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->