### PR TITLE
Allow to interrupt startup using any key

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -314,3 +314,68 @@ func PrintErrorString(err string) {
 func PrintError(err error) {
 	PrintErrorString(err.Error())
 }
+
+func WaitForKeyboardInterrupt() (<-chan bool, func()) {
+	ch := make(chan bool, 1)
+	done := make(chan struct{})
+
+	var cleanup func()
+	var cancelled bool
+
+	go func() {
+		initialState, err := term.GetState(syscall.Stdin)
+		if err != nil {
+			return
+		}
+
+		// Set terminal to raw mode to capture individual keystrokes
+		term.MakeRaw(syscall.Stdin)
+
+		restoreTerminal := func() {
+			term.Restore(syscall.Stdin, initialState)
+			fmt.Print("\r") // Move to beginning of new line after restore
+		}
+
+		cleanup = restoreTerminal
+		defer func() {
+			if !cancelled {
+				restoreTerminal()
+			}
+		}()
+
+		// Handle signals to restore terminal state
+		signalChan := make(chan os.Signal, 1)
+		signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-signalChan
+			restoreTerminal()
+			os.Exit(1)
+		}()
+
+		// Wait for any key press or cancellation
+		buffer := make([]byte, 1)
+
+		// Use select to handle both key press and cancellation
+		go func() {
+			os.Stdin.Read(buffer)
+			select {
+			case ch <- true:
+			case <-done:
+			}
+		}()
+
+		<-done // Wait for cancellation
+	}()
+
+	cancel := func() {
+		if !cancelled {
+			cancelled = true
+			if cleanup != nil {
+				cleanup()
+			}
+			close(done)
+		}
+	}
+
+	return ch, cancel
+}


### PR DESCRIPTION
Allow the user to interrupt the startup wait by pressing any key. This can be helpful to debug why the Supervisor is taking longer than expected to start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added interactive waiting in the banner command with a keyboard interrupt to exit early.
  - Introduced immediate readiness detection and periodic checks for faster feedback.
  - Implemented timeout handling with clear user-facing messages.

- Bug Fixes
  - Ensures the terminal is reliably restored after waiting or interruption.
  - Eliminates the previous long, fixed-duration blocking wait, improving responsiveness and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->