### PR TITLE
feat: Add mDNS/LLMNR network options

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -36,6 +36,10 @@ func ip6PrivacyCompletions(cmd *cobra.Command, args []string, toComplete string)
 	return []string{"disabled", "enabled-prefer-public", "enabled", "default"}, cobra.ShellCompDirectiveNoFileComp
 }
 
+func mdnsCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"default", "off", "resolve", "announce"}, cobra.ShellCompDirectiveNoFileComp
+}
+
 func networkInterfaceCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) != 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/network_update.go
+++ b/cmd/network_update.go
@@ -48,6 +48,9 @@ Update network interface settings of a specific adapter.
 		// Wifi
 		helperWifiConfig(cmd, options)
 
+		// mDNS / LLMNR
+		helperMdnsConfig(cmd, options)
+
 		disabled, err := cmd.Flags().GetBool("disabled")
 		if err == nil {
 			options["enabled"] = !disabled
@@ -89,6 +92,9 @@ func init() {
 
 	networkUpdateCmd.Flags().BoolP("disabled", "e", false, "Disable interface")
 
+	networkUpdateCmd.Flags().String("mdns", "", "mDNS mode: default|off|resolve|announce")
+	networkUpdateCmd.Flags().String("llmnr", "", "LLMNR mode: default|off|resolve|announce")
+
 	networkUpdateCmd.RegisterFlagCompletionFunc("ipv4-address", cobra.NoFileCompletions)
 	networkUpdateCmd.RegisterFlagCompletionFunc("ipv4-gateway", cobra.NoFileCompletions)
 	networkUpdateCmd.RegisterFlagCompletionFunc("ipv4-method", ipMethodCompletions)
@@ -111,6 +117,9 @@ func init() {
 	networkUpdateCmd.RegisterFlagCompletionFunc("wifi-psk", cobra.NoFileCompletions)
 
 	networkUpdateCmd.RegisterFlagCompletionFunc("disabled", boolCompletions)
+
+	networkUpdateCmd.RegisterFlagCompletionFunc("mdns", mdnsCompletions)
+	networkUpdateCmd.RegisterFlagCompletionFunc("llmnr", mdnsCompletions)
 
 	networkCmd.AddCommand(networkUpdateCmd)
 }
@@ -170,5 +179,17 @@ func helperWifiConfig(cmd *cobra.Command, options map[string]any) {
 	wifiConfig := parseNetworkArgs(cmd, args)
 	if len(wifiConfig) > 0 {
 		options["wifi"] = wifiConfig
+	}
+}
+
+func helperMdnsConfig(cmd *cobra.Command, options map[string]any) {
+	mdns, err := cmd.Flags().GetString("mdns")
+	if err == nil && mdns != "" {
+		options["mdns"] = mdns
+	}
+
+	llmnr, err := cmd.Flags().GetString("llmnr")
+	if err == nil && llmnr != "" {
+		options["llmnr"] = llmnr
 	}
 }

--- a/cmd/network_vlan.go
+++ b/cmd/network_vlan.go
@@ -48,6 +48,9 @@ This function works only on an ethernet interface!
 		helperIpConfig("ipv4", cmd, options)
 		helperIpConfig("ipv6", cmd, options)
 
+		// mDNS / LLMNR
+		helperMdnsConfig(cmd, options)
+
 		if len(options) > 0 {
 			log.WithField("options", options).Debug("Request body")
 			request.SetBody(options)
@@ -79,6 +82,9 @@ func init() {
 	networkVlanCmd.Flags().String("ipv6-privacy", "", "IPv6 privacy extensions: disabled|enabled-prefer-public|enabled|default")
 	networkVlanCmd.Flags().StringArray("ipv6-nameserver", []string{}, "IPv6 address for upstream DNS servers. Use multiple times for multiple servers.")
 
+	networkVlanCmd.Flags().String("mdns", "", "mDNS mode: default|off|resolve|announce")
+	networkVlanCmd.Flags().String("llmnr", "", "LLMNR mode: default|off|resolve|announce")
+
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv4-address", cobra.NoFileCompletions)
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv4-gateway", cobra.NoFileCompletions)
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv4-method", ipMethodCompletions)
@@ -90,6 +96,9 @@ func init() {
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-addr-gen-mode", ipAddrGenModeCompletions)
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-privacy", ip6PrivacyCompletions)
 	networkVlanCmd.RegisterFlagCompletionFunc("ipv6-nameserver", cobra.NoFileCompletions)
+
+	networkVlanCmd.RegisterFlagCompletionFunc("mdns", mdnsCompletions)
+	networkVlanCmd.RegisterFlagCompletionFunc("llmnr", mdnsCompletions)
 
 	networkCmd.AddCommand(networkVlanCmd)
 }


### PR DESCRIPTION
This PR adds mDNS/LLMNR options to network update/vlan commands.

Related to https://github.com/home-assistant/supervisor/pull/5520