### PR TITLE
Add disks usage API

### DIFF
--- a/cmd/host_disks.go
+++ b/cmd/host_disks.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var hostDisksCmd = &cobra.Command{
+	Use:     "disks",
+	Aliases: []string{"disk"},
+	Short:   "Manage host disk operations",
+	Long: `
+The disks command provides access to disk-related operations on the host system
+that Home Assistant is running on.`,
+	Example: `
+  ha host disks usage`,
+}
+
+func init() {
+	hostCmd.AddCommand(hostDisksCmd)
+}

--- a/cmd/host_disks_usage.go
+++ b/cmd/host_disks_usage.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	helper "github.com/home-assistant/cli/client"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var hostDisksUsageCmd = &cobra.Command{
+	Use:     "usage",
+	Aliases: []string{"us", "use"},
+	Short:   "Get default disk usage information",
+	Long: `
+This command provides information about the default disk usage on the host system
+that Home Assistant is running on.`,
+	Example: `
+  ha host disks usage`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithField("args", args).Debug("host disks usage")
+
+		section := "host"
+		command := "disks/default/usage"
+
+		resp, err := helper.GenericJSONGet(section, command)
+		if err != nil {
+			helper.PrintError(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	hostDisksCmd.AddCommand(hostDisksUsageCmd)
+}


### PR DESCRIPTION
Add CLI support for the host disks usage API as added in https://github.com/home-assistant/supervisor/pull/6046

Although the API is hard coded to `host/disks/default/usage`, `default` is intended to be an argument in the future where the user could put the ID of a different mounted disk. Therefore it is intentionally omitted from the command for now, it can become a command arg later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new “host disks” CLI command (alias: “disk”) to manage host disk operations.
  * Added a “usage” subcommand (aliases: “us”, “use”) to display default host disk usage.
  * Provides clear descriptions, examples, and argument validation for a smoother CLI experience.
  * Example: ha host disks usage to fetch and display disk usage in JSON format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->