### PR TITLE
Remove deprecated options

### DIFF
--- a/cmd/core_options.go
+++ b/cmd/core_options.go
@@ -17,7 +17,7 @@ var coreOptionsCmd = &cobra.Command{
 This command allows you to set configuration options for the Home Assistant Core
 instance running on your Home Assistant system.`,
 	Example: `
-  ha core options --wait_boot 600`,
+  ha core options --backups-exclude-database=true`,
 	ValidArgsFunction: cobra.NoFileCompletions,
 	Args:              cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/supervisor_options.go
+++ b/cmd/supervisor_options.go
@@ -54,18 +54,6 @@ Supervisor running on your Home Assistant system.`,
 			}
 		}
 
-		waitboot, _ := cmd.Flags().GetInt("wait-boot")
-		if cmd.Flags().Changed("wait-boot") {
-			options["wait_boot"] = waitboot
-		}
-
-		repos, err := cmd.Flags().GetStringArray("repositories")
-		log.WithField("repositories", repos).Debug("repos")
-
-		if len(repos) >= 1 && err == nil {
-			options["addons_repositories"] = repos
-		}
-
 		resp, err := helper.GenericJSONPost(section, command, options)
 		if err != nil {
 			helper.PrintError(err)
@@ -82,12 +70,10 @@ func init() {
 	supervisorOptionsCmd.Flags().StringP("detect-blocking-io", "", "", "Detect blocking IO (on|on-at-startup|off)")
 	supervisorOptionsCmd.Flags().StringP("timezone", "t", "", "Timezone")
 	supervisorOptionsCmd.Flags().StringP("logging", "l", "", "Logging: debug|info|warning|error|critical")
-	supervisorOptionsCmd.Flags().IntP("wait-boot", "w", 0, "Seconds to wait after boot")
 	supervisorOptionsCmd.Flags().BoolP("debug", "", false, "Enable debug mode")
 	supervisorOptionsCmd.Flags().BoolP("debug-block", "", false, "Enable debug mode with blocking startup")
 	supervisorOptionsCmd.Flags().BoolP("diagnostics", "", false, "Enable diagnostics mode")
 	supervisorOptionsCmd.Flags().BoolP("auto-update", "", true, "Enable/disable supervisor auto update")
-	supervisorOptionsCmd.Flags().StringArrayP("repositories", "r", []string{}, "repositories to track, can be supplied multiple times")
 
 	supervisorOptionsCmd.Flags().Lookup("debug").NoOptDefVal = "false"
 	supervisorOptionsCmd.Flags().Lookup("debug-block").NoOptDefVal = "false"
@@ -105,11 +91,9 @@ func init() {
 	supervisorOptionsCmd.RegisterFlagCompletionFunc("logging", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"debug", "info", "warning", "error", "critical"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	supervisorOptionsCmd.RegisterFlagCompletionFunc("wait-boot", cobra.NoFileCompletions)
 	supervisorOptionsCmd.RegisterFlagCompletionFunc("debug", boolCompletions)
 	supervisorOptionsCmd.RegisterFlagCompletionFunc("debug-block", boolCompletions)
 	supervisorOptionsCmd.RegisterFlagCompletionFunc("diagnostics", boolCompletions)
-	supervisorOptionsCmd.RegisterFlagCompletionFunc("repositories", cobra.NoFileCompletions)
 
 	supervisorCmd.AddCommand(supervisorOptionsCmd)
 }


### PR DESCRIPTION
Remove support for deprecated supervisor options: `wait-boot` and `repositories`. These will be dropped in https://github.com/home-assistant/supervisor/pull/6226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated CLI flags for supervisor options: wait-boot and repositories are no longer supported.
  * Eliminated associated handling and completions for these flags in the CLI.

* **Documentation**
  * Updated core options usage examples to reflect current flags, replacing wait_boot with backups-exclude-database.
  * Refreshed help text to align with the removal of unsupported flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->