### PR TITLE
Increase mounts reload timeout to 5 minutes

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -30,6 +30,7 @@ const ContainerDownloadTimeout = 1 * time.Hour
 const OsDownloadTimeout = 1 * time.Hour
 const BackupTimeout = 3 * time.Hour
 const RebootTimeout = 90 * time.Second
+const MountTimeout = 5 * time.Minute
 
 var client *resty.Client
 

--- a/cmd/mounts_reload.go
+++ b/cmd/mounts_reload.go
@@ -33,7 +33,7 @@ the same configuration.
 			return
 		}
 
-		request := helper.GetJSONRequest()
+		request := helper.GetJSONRequestTimeout(helper.MountTimeout)
 
 		name := args[0]
 		request.SetPathParams(map[string]string{


### PR DESCRIPTION
Reloading a mount can take longer than the default 30s timeout, especially for network shares that are slow to (un)mount. Introduce a dedicated MountTimeout constant and use it for the mounts reload command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Added a 5-minute timeout to the mounts reload operation to enhance reliability and prevent indefinite hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->