### PR TITLE
Add --search-domains flag to dns options command

### DIFF
--- a/cmd/dns_options.go
+++ b/cmd/dns_options.go
@@ -17,6 +17,7 @@ running Home Assistant DNS server.
 `,
 	Example: `
   ha dns options --servers dns://8.8.8.8 --servers dns://1.1.1.1
+  ha dns options --search-domains example.com --search-domains corp.example.com
 `,
 	ValidArgsFunction: cobra.NoFileCompletions,
 	Args:              cobra.NoArgs,
@@ -33,6 +34,13 @@ running Home Assistant DNS server.
 
 		if len(servers) >= 1 && err == nil {
 			options["servers"] = servers
+		}
+
+		searchDomains, err := cmd.Flags().GetStringArray("search-domains")
+		log.WithField("search-domains", searchDomains).Debug("search-domains")
+
+		if cmd.Flags().Changed("search-domains") && err == nil {
+			options["search_domains"] = searchDomains
 		}
 
 		data, err := cmd.Flags().GetBool("fallback")
@@ -52,11 +60,13 @@ running Home Assistant DNS server.
 
 func init() {
 	dnsOptionsCmd.Flags().StringArrayP("servers", "r", []string{}, "Upstream DNS servers to use. Use multiple times for multiple servers.")
+	dnsOptionsCmd.Flags().StringArray("search-domains", []string{}, "DNS search domains written to container resolv.conf. Use multiple times for multiple domains.")
 	dnsOptionsCmd.Flags().BoolP("fallback", "", true, "Enable/Disable fallback DNS (Cloudflare DoT)")
 
 	dnsOptionsCmd.Flags().Lookup("fallback").NoOptDefVal = "true"
 
 	dnsOptionsCmd.RegisterFlagCompletionFunc("servers", cobra.NoFileCompletions)
+	dnsOptionsCmd.RegisterFlagCompletionFunc("search-domains", cobra.NoFileCompletions)
 	dnsOptionsCmd.RegisterFlagCompletionFunc("fallback", boolCompletions)
 
 	dnsCmd.AddCommand(dnsOptionsCmd)

--- a/cmd/dns_options.go
+++ b/cmd/dns_options.go
@@ -37,7 +37,7 @@ running Home Assistant DNS server.
 		}
 
 		searchDomains, err := cmd.Flags().GetStringArray("search-domains")
-		log.WithField("search-domains", searchDomains).Debug("search-domains")
+		slog.Debug("search-domains", "search-domains", searchDomains)
 
 		if cmd.Flags().Changed("search-domains") && err == nil {
 			options["search_domains"] = searchDomains


### PR DESCRIPTION
Expose the supervisor's search_domains DNS option (https://github.com/home-assistant/supervisor/pull/6893) via the CLI, mirroring the existing --servers flag. Accepts multiple values via repeated use of the flag.

  ha dns options --search-domains example.com --search-domains corp.example.com

Peer of https://github.com/home-assistant/supervisor/pull/6893 and requires that PR first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `ha dns options` command now supports the `--search-domains` flag to configure DNS search domains.
  * Command examples and help text have been updated to show usage of the new flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->