### PR TITLE
Add Raspberry Pi firmware info/update commands

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -114,6 +114,14 @@ func GetRequestTimeout(timeout time.Duration) *resty.Request {
 
 // ShowJSONResponse formats a JSON response for human readers
 func ShowJSONResponse(resp *resty.Response) (success bool) {
+	return ShowJSONResponseTransform(resp, nil)
+}
+
+// ShowJSONResponseTransform formats a JSON response for human readers, applying
+// transform to the data map of a successful response before rendering it. This
+// allows commands to humanize individual fields. In raw JSON mode the transform
+// is not applied, as the output is meant for machine consumption.
+func ShowJSONResponseTransform(resp *resty.Response, transform func(map[string]any)) (success bool) {
 	if RawJSON {
 		// when we are returning raw JSON, all handling is for the consumer of the JSON
 		success = true
@@ -135,6 +143,9 @@ func ShowJSONResponse(resp *resty.Response) (success bool) {
 		if len(data.Data) == 0 {
 			fmt.Println("Command completed successfully.")
 		} else {
+			if transform != nil {
+				transform(data.Data)
+			}
 			j, err := json.Marshal(data.Data)
 			if err != nil {
 				PrintError(err)

--- a/cmd/os_boards_raspberrypi.go
+++ b/cmd/os_boards_raspberrypi.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var osBoardsRaspberrypiCmd = &cobra.Command{
+	Use:     "raspberrypi",
+	Aliases: []string{"rpi"},
+	Short:   "See or change settings of the current Raspberry Pi board",
+	Long: `
+This command allows you to see or change settings of the Raspberry Pi board that
+Home Assistant is running on.`,
+	Example: `
+  ha os boards raspberrypi firmware`,
+}
+
+func init() {
+	osBoardsCmd.AddCommand(osBoardsRaspberrypiCmd)
+}

--- a/cmd/os_boards_raspberrypi_firmware.go
+++ b/cmd/os_boards_raspberrypi_firmware.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	resty "github.com/go-resty/resty/v2"
+	helper "github.com/home-assistant/cli/client"
+	"github.com/spf13/cobra"
+)
+
+// getRPiFirmwareInfo fetches the Raspberry Pi firmware status. A 404 is turned
+// into a friendly error in case the API doesn't return it already.
+func getRPiFirmwareInfo() (*resty.Response, error) {
+	url, err := helper.URLHelper("os", "boards/raspberrypi/firmware")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := helper.GetJSONRequestTimeout(helper.DefaultTimeout).Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode() == http.StatusNotFound {
+		// Prefer the Supervisor's own message when it returns a JSON body,
+		// otherwise (e.g. a bare 404 from an older Supervisor) explain why.
+		if data, ok := resp.Error().(*helper.Response); ok && data.Message != "" {
+			return nil, errors.New(data.Message)
+		}
+		return nil, errors.New("firmware information is not available on this system " +
+			"(requires a Raspberry Pi 4 / 5 or Home Assistant Yellow with Home Assistant OS 18.0 or newer)")
+	}
+
+	return helper.GenericJSONErrorHandling(resp, err)
+}
+
+// humanizeRPiFirmwareVersion turns a raw firmware version into a human-readable
+// string. The Supervisor reports the bootloader EEPROM build as a Unix timestamp,
+// optionally suffixed with the VL805 EEPROM revision (timestamp-hexstring). It
+// renders the timestamp as a UTC YYYY-MM-DD date and appends (VL805 hexstring)
+// when a VL805 revision is present.
+func humanizeRPiFirmwareVersion(version string) string {
+	if version == "" {
+		return version
+	}
+	timestamp, vl805, _ := strings.Cut(version, "-")
+	secs, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return version
+	}
+	date := time.Unix(secs, 0).UTC().Format("2006-01-02")
+	if vl805 != "" {
+		return fmt.Sprintf("%s (VL805 %s)", date, vl805)
+	}
+	return date
+}
+
+// humanizeRPiFirmwareData humanizes the version fields of a firmware info response
+// in place, leaving non-string values (e.g. null) untouched.
+func humanizeRPiFirmwareData(data map[string]any) {
+	for _, key := range []string{"current_version", "latest_version"} {
+		if v, ok := data[key].(string); ok {
+			data[key] = humanizeRPiFirmwareVersion(v)
+		}
+	}
+}
+
+var osBoardsRaspberrypiFirmwareCmd = &cobra.Command{
+	Use:     "firmware",
+	Aliases: []string{"fw"},
+	Short:   "Show Raspberry Pi firmware information",
+	Long: `
+This command shows information about the Raspberry Pi bootloader (EEPROM) firmware,
+including the currently installed and latest bundled versions and whether an update
+is available. Available on Raspberry Pi 4 / 5 and Home Assistant Yellow.`,
+	Example: `
+  ha os boards raspberrypi firmware`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		slog.Debug("os boards raspberrypi firmware", "args", args)
+
+		resp, err := getRPiFirmwareInfo()
+		if err != nil {
+			helper.PrintError(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponseTransform(resp, humanizeRPiFirmwareData)
+		}
+	},
+}
+
+func init() {
+	osBoardsRaspberrypiCmd.AddCommand(osBoardsRaspberrypiFirmwareCmd)
+}

--- a/cmd/os_boards_raspberrypi_firmware_update.go
+++ b/cmd/os_boards_raspberrypi_firmware_update.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+
+	helper "github.com/home-assistant/cli/client"
+	"github.com/spf13/cobra"
+)
+
+var osBoardsRaspberrypiFirmwareUpdateCmd = &cobra.Command{
+	Use:     "update",
+	Aliases: []string{"up", "upgrade"},
+	Short:   "Apply the bundled Raspberry Pi firmware update",
+	Long: `
+This command applies the bundled Raspberry Pi firmware update (bootloader EEPROM,
+and VL805 where present). A reboot is required for the new firmware to take effect.`,
+	Example: `
+  ha os boards raspberrypi firmware update`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		slog.Debug("os boards raspberrypi firmware update", "args", args)
+
+		// Fetch the current firmware status first so we can fail gracefully.
+		infoResp, err := getRPiFirmwareInfo()
+		if err != nil {
+			helper.PrintError(err)
+			ExitWithError = true
+			return
+		}
+		if !infoResp.IsSuccess() {
+			// Other API errors (e.g. a 400) come back with a message to show.
+			ExitWithError = true
+			helper.ShowJSONResponse(infoResp)
+			return
+		}
+
+		info := infoResp.Result().(*helper.Response)
+
+		if blocked, _ := info.Data["update_blocked"].(bool); blocked {
+			msg := "firmware update is blocked"
+			if reason, _ := info.Data["blocked_reason"].(string); reason != "" {
+				msg = fmt.Sprintf("%s: %s", msg, reason)
+			}
+			helper.PrintErrorString(msg)
+			ExitWithError = true
+			return
+		}
+
+		if pending, _ := info.Data["update_pending"].(bool); pending {
+			fmt.Println("A firmware update is already pending. Reboot the device using `ha host reboot` to finish the installation.")
+			return
+		}
+
+		if available, ok := info.Data["update_available"].(bool); ok && !available {
+			msg := "The Raspberry Pi firmware is already up to date."
+			if current, _ := info.Data["current_version"].(string); current != "" {
+				msg = fmt.Sprintf("The Raspberry Pi firmware is already up to date (%s).", humanizeRPiFirmwareVersion(current))
+			}
+			fmt.Println(msg)
+			return
+		}
+
+		prompt := "This applies the bundled Raspberry Pi firmware update and requires a reboot to take effect."
+		current, _ := info.Data["current_version"].(string)
+		latest, _ := info.Data["latest_version"].(string)
+		if current != "" && latest != "" {
+			prompt = fmt.Sprintf("This will update the Raspberry Pi firmware from %s to %s and requires a reboot to take effect.",
+				humanizeRPiFirmwareVersion(current), humanizeRPiFirmwareVersion(latest))
+		}
+
+		confirmed, err := helper.AskForConfirmation(prompt+" Continue?", 2)
+		if err != nil {
+			helper.PrintError(err)
+			ExitWithError = true
+			return
+		}
+		if !confirmed {
+			fmt.Println("Aborted.")
+			return
+		}
+
+		fmt.Println("\nApplying firmware update. Please be patient and do not unplug or power off the device.")
+
+		ProgressSpinner.Start()
+		resp, err := helper.GenericJSONPost("os", "boards/raspberrypi/firmware/update", make(map[string]any))
+		ProgressSpinner.Stop()
+		if err != nil {
+			helper.PrintError(err)
+			ExitWithError = true
+		} else if helper.ShowJSONResponse(resp) {
+			fmt.Println("\nFirmware update applied. Reboot the device using `ha host reboot` to finish the installation.")
+		} else {
+			ExitWithError = true
+		}
+	},
+}
+
+func init() {
+	osBoardsRaspberrypiFirmwareCmd.AddCommand(osBoardsRaspberrypiFirmwareUpdateCmd)
+}

--- a/cmd/os_boards_raspberrypi_firmware_update.go
+++ b/cmd/os_boards_raspberrypi_firmware_update.go
@@ -72,12 +72,13 @@ and VL805 where present). A reboot is required for the new firmware to take effe
 
 		confirmed, err := helper.AskForConfirmation(prompt+" Continue?", 2)
 		if err != nil {
-			helper.PrintError(err)
+			cmd.PrintErrln("Aborted:", err)
 			ExitWithError = true
 			return
 		}
 		if !confirmed {
-			fmt.Println("Aborted.")
+			cmd.PrintErrln("Aborted.")
+			ExitWithError = true
 			return
 		}
 


### PR DESCRIPTION
Add commands for CLI operations for retrieving the firmware update status and updating the EEPROM bootloader. Uses API added in Supervisor in home-assistant/supervisor#6886.

The `ha os boards raspberrypi firmware` commands returns the raw API response with bootloader version humanized (using the same translation that Core uses in home-assistant/core#172929), the `... update` command first checks the API if the update can be applied and then installs it, prompting the user to reboot the device afterwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Raspberry Pi board commands for viewing and applying firmware updates.
  * Firmware updates include confirmation prompts, progress indication, and reboot reminders.
  * Firmware versions now display in user-friendly date format.
  * JSON output can be transformed before display for clearer presentation.

* **Bug Fixes**
  * Improved error messages when firmware info is unavailable or when updates are blocked/pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->