### PR TITLE
Inform user that manual reboot is required after os upate

### DIFF
--- a/cmd/os_update.go
+++ b/cmd/os_update.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 
 	helper "github.com/home-assistant/cli/client"
@@ -40,6 +41,8 @@ Operating System to the latest version or the version specified.
 		if err != nil {
 			helper.PrintError(err)
 			ExitWithError = true
+		} else if helper.ShowJSONResponse(resp) {
+			fmt.Println("\nOS update applied. Reboot the device using `ha host reboot` to finish the update.")
 		} else {
 			ExitWithError = !helper.ShowJSONResponse(resp)
 		}

--- a/cmd/os_update.go
+++ b/cmd/os_update.go
@@ -44,7 +44,7 @@ Operating System to the latest version or the version specified.
 		} else if helper.ShowJSONResponse(resp) {
 			fmt.Println("\nOS update applied. Reboot the device using `ha host reboot` to finish the update.")
 		} else {
-			ExitWithError = !helper.ShowJSONResponse(resp)
+			ExitWithError = true
 		}
 	},
 }


### PR DESCRIPTION
After https://github.com/home-assistant/supervisor/pull/6982 the system will no longer reboot automatically as part of a call to `/os/update`. Instead it will create a repair letting the user know a reboot is required so they can easily do it on their schedule. Repairs don't appear in the CLI so we print a message telling them this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When requesting JSON output, a successful OS update now shows an explicit confirmation message instead of relying on the previous success handling.
  * The CLI also includes a reminder to reboot the host (via `ha host reboot`) to complete the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->