### PR TITLE
workflows: build: use gh CLI to upload release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build ${{ matrix.variant.name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         variant:
@@ -34,11 +36,6 @@ jobs:
 
     - name: Upload release asset
       if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1.0.2
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: "${{ github.workspace }}/${{ matrix.variant.name }}"
-        asset_name: ${{ matrix.variant.name }}
-        asset_content_type: application/x-binary
+        GH_TOKEN: ${{ github.token }}
+      run: gh release upload "${{ github.event.release.tag_name }}" "${{ matrix.variant.name }}" --clobber


### PR DESCRIPTION
Replaces the deprecated `actions/upload-release-asset@v1.0.2` action ([archived since 2020](https://github.com/actions/upload-release-asset)) with the first-party GitHub CLI (`gh release upload`), which is pre-installed on the runners.

### Why
- The old action is unmaintained and archived.
- Removes a third-party action dependency (no tag/SHA to pin or trust).
- Matches the approach other Home Assistant repos have moved to — e.g. `frontend` and `android` both use `gh release upload ... --clobber`.
- `--clobber` makes re-runs idempotent (overwrites an existing asset instead of failing).

### Note
The default `GITHUB_TOKEN` is read-only for organization repos, so the job now explicitly requests `contents: write` to upload release assets (mirroring home-assistant/tempio#124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the release process for built binaries.
  - Release assets are now uploaded more reliably and can be replaced when necessary.
  - Updated build permissions and authentication handling to support smoother automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->