### PR TITLE
Add local disk mounts to the mounts commands

### DIFF
--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -131,6 +131,12 @@ func backupsLocationsCompletions(cmd *cobra.Command, args []string, toComplete s
 				if s, ok = m["path"].(string); ok && s != "" {
 					ds = append(ds, s)
 				}
+				if s, ok = m["uuid"].(string); ok && s != "" {
+					ds = append(ds, s)
+				}
+				if s, ok = m["filesystem"].(string); ok && s != "" {
+					ds = append(ds, s)
+				}
 				if len(ds) != 0 {
 					ret[len(ret)-1] += "\t" + strings.Join(ds, ", ")
 				}

--- a/cmd/mounts.go
+++ b/cmd/mounts.go
@@ -57,9 +57,8 @@ func addMountFlags(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("read-only", boolCompletions)
 }
 
-// mountFlagsToOptions copies only the flags the user set: Supervisor validates
-// the whole mount config, so passing an untouched flag along would rewrite the
-// mount's type or usage to the flag default.
+// Copy only flags the user set. Sending an untouched default would rewrite
+// type or usage on update.
 func mountFlagsToOptions(cmd *cobra.Command, options map[string]any) {
 	for _, value := range []string{
 		"type",
@@ -90,9 +89,7 @@ func mountFlagsToOptions(cmd *cobra.Command, options map[string]any) {
 	}
 }
 
-// mountFlagsToNewOptions is mountFlagsToOptions for creating a mount, where the
-// type and usage defaults are part of the new config rather than an unwanted
-// change to an existing mount.
+// Like mountFlagsToOptions, but include type/usage defaults for a new mount.
 func mountFlagsToNewOptions(cmd *cobra.Command, options map[string]any) {
 	mountFlagsToOptions(cmd, options)
 

--- a/cmd/mounts.go
+++ b/cmd/mounts.go
@@ -33,11 +33,14 @@ func addMountFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("password", "p", "", "Password to use for authentication (cifs mounts only)")
 	cmd.Flags().StringP("version", "v", "", "Version to use for the mount (cifs mounts only)")
 	cmd.Flags().StringP("path", "a", "", "Path to mount (nfs mounts only)")
+	cmd.Flags().String("device", "", "Device to mount, e.g. /dev/sda1 (disk mounts only)")
+	cmd.Flags().String("uuid", "", "Filesystem UUID of the device to mount (disk mounts only)")
 	cmd.Flags().Bool("read-only", false, "Is mount read-only (not available for backup mounts)")
 
 	cmd.Flags().Lookup("read-only").NoOptDefVal = "true"
+	cmd.MarkFlagsMutuallyExclusive("device", "uuid")
 	cmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"cifs", "nfs"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"cifs", "nfs", "disk"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.RegisterFlagCompletionFunc("usage", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"backup", "media", "share"}, cobra.ShellCompDirectiveNoFileComp
@@ -49,9 +52,14 @@ func addMountFlags(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("password", cobra.NoFileCompletions)
 	cmd.RegisterFlagCompletionFunc("version", cobra.NoFileCompletions)
 	cmd.RegisterFlagCompletionFunc("path", cobra.NoFileCompletions)
+	cmd.RegisterFlagCompletionFunc("device", mountsCandidatesDeviceCompletions)
+	cmd.RegisterFlagCompletionFunc("uuid", cobra.NoFileCompletions)
 	cmd.RegisterFlagCompletionFunc("read-only", boolCompletions)
 }
 
+// mountFlagsToOptions copies only the flags the user set: Supervisor validates
+// the whole mount config, so passing an untouched flag along would rewrite the
+// mount's type or usage to the flag default.
 func mountFlagsToOptions(cmd *cobra.Command, options map[string]any) {
 	for _, value := range []string{
 		"type",
@@ -62,9 +70,11 @@ func mountFlagsToOptions(cmd *cobra.Command, options map[string]any) {
 		"username",
 		"password",
 		"version",
+		"device",
+		"uuid",
 	} {
 		val, err := cmd.Flags().GetString(value)
-		if val != "" && err == nil {
+		if val != "" && err == nil && cmd.Flags().Changed(value) {
 			options[value] = val
 		}
 	}
@@ -77,6 +87,22 @@ func mountFlagsToOptions(cmd *cobra.Command, options map[string]any) {
 	roVal, roErr := cmd.Flags().GetBool("read-only")
 	if roErr == nil && cmd.Flags().Changed("read-only") {
 		options["read_only"] = roVal
+	}
+}
+
+// mountFlagsToNewOptions is mountFlagsToOptions for creating a mount, where the
+// type and usage defaults are part of the new config rather than an unwanted
+// change to an existing mount.
+func mountFlagsToNewOptions(cmd *cobra.Command, options map[string]any) {
+	mountFlagsToOptions(cmd, options)
+
+	for _, value := range []string{"type", "usage"} {
+		if _, ok := options[value]; ok {
+			continue
+		}
+		if val, err := cmd.Flags().GetString(value); err == nil && val != "" {
+			options[value] = val
+		}
 	}
 }
 
@@ -116,6 +142,12 @@ func mountsCompletions(cmd *cobra.Command, args []string, toComplete string) ([]
 					ds = append(ds, s)
 				}
 				if s, ok = m["path"].(string); ok && s != "" {
+					ds = append(ds, s)
+				}
+				if s, ok = m["uuid"].(string); ok && s != "" {
+					ds = append(ds, s)
+				}
+				if s, ok = m["filesystem"].(string); ok && s != "" {
 					ds = append(ds, s)
 				}
 				if len(ds) != 0 {

--- a/cmd/mounts_add.go
+++ b/cmd/mounts_add.go
@@ -16,6 +16,7 @@ Add and configure a new mount in Supervisor.
 `,
 	Example: `
   ha mounts add my_share --usage media --type cifs --server server.local --share media
+  ha mounts add media_disk --usage media --type disk --device /dev/sda1
 `,
 	ValidArgsFunction: mountsCompletions,
 	Args:              cobra.ExactArgs(1),
@@ -32,13 +33,13 @@ Add and configure a new mount in Supervisor.
 			return
 		}
 
-		request := helper.GetJSONRequest()
+		request := helper.GetJSONRequestTimeout(helper.MountTimeout)
 
 		name := args[0]
 		options := make(map[string]any)
 
 		options["name"] = name
-		mountFlagsToOptions(cmd, options)
+		mountFlagsToNewOptions(cmd, options)
 
 		if len(options) > 0 {
 			slog.Debug("Request body", "options", options)

--- a/cmd/mounts_candidates.go
+++ b/cmd/mounts_candidates.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	helper "github.com/home-assistant/cli/client"
+	"github.com/spf13/cobra"
+)
+
+var mountsCandidatesCmd = &cobra.Command{
+	Use:     "candidates",
+	Aliases: []string{"can", "cand"},
+	Short:   "Shows local disks which could be mounted",
+	Long: `
+Shows the local block devices Supervisor considers usable as a disk mount,
+along with details of the drive each one belongs to.
+`,
+	Example: `
+  ha mounts candidates
+`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		slog.Debug("mounts candidates", "args", args)
+
+		section := "mounts"
+		command := "candidates"
+
+		resp, err := helper.GenericJSONGet(section, command)
+		if err != nil {
+			helper.PrintError(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+// mountsCandidatesDeviceCompletions offers the devices Supervisor reports as
+// mountable, offering nothing at all if it cannot ask: a host without UDisks2
+// returns an empty list, and a Supervisor predating the endpoint returns 404.
+func mountsCandidatesDeviceCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	resp, err := helper.GenericJSONGet("mounts", "candidates")
+	if err != nil || !resp.IsSuccess() {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var ret []string
+	data := resp.Result().(*helper.Response)
+	if data.Result == "ok" && data.Data["candidates"] != nil {
+		if candidates, ok := data.Data["candidates"].([]any); ok {
+			for _, candidate := range candidates {
+				var c map[string]any
+				if c, ok = candidate.(map[string]any); !ok {
+					continue
+				}
+				var device string
+				if device, ok = c["device"].(string); !ok || device == "" {
+					continue
+				}
+				ret = append(ret, device)
+				if ds := mountCandidateDescription(c); ds != "" {
+					ret[len(ret)-1] += "\t" + ds
+				}
+			}
+		}
+	}
+	return ret, cobra.ShellCompDirectiveNoFileComp
+}
+
+func mountCandidateDescription(candidate map[string]any) string {
+	var ds []string
+	if drive, ok := candidate["drive"].(map[string]any); ok {
+		var name []string
+		for _, key := range []string{"vendor", "model"} {
+			if s, ok := drive[key].(string); ok && s != "" {
+				name = append(name, s)
+			}
+		}
+		if len(name) != 0 {
+			ds = append(ds, strings.Join(name, " "))
+		}
+	}
+	if s, ok := candidate["label"].(string); ok && s != "" {
+		ds = append(ds, s)
+	}
+	if size, ok := candidate["size"].(float64); ok && size > 0 {
+		ds = append(ds, humanizeMountSize(size))
+	}
+	return strings.Join(ds, ", ")
+}
+
+// humanizeMountSize uses decimal units, the way drive capacity is labelled.
+func humanizeMountSize(size float64) string {
+	units := []string{"B", "kB", "MB", "GB", "TB"}
+	i := 0
+	for size >= 1000 && i < len(units)-1 {
+		size /= 1000
+		i++
+	}
+	if i == 0 {
+		return fmt.Sprintf("%.0f %s", size, units[i])
+	}
+	return fmt.Sprintf("%.1f %s", size, units[i])
+}
+
+func init() {
+	mountsCmd.AddCommand(mountsCandidatesCmd)
+}

--- a/cmd/mounts_candidates.go
+++ b/cmd/mounts_candidates.go
@@ -14,8 +14,8 @@ var mountsCandidatesCmd = &cobra.Command{
 	Aliases: []string{"can", "cand"},
 	Short:   "Shows local disks which could be mounted",
 	Long: `
-Shows the local block devices Supervisor considers usable as a disk mount,
-along with details of the drive each one belongs to.
+Shows local block devices Supervisor can use as a disk mount, including
+the drive each one belongs to.
 `,
 	Example: `
   ha mounts candidates
@@ -38,9 +38,7 @@ along with details of the drive each one belongs to.
 	},
 }
 
-// mountsCandidatesDeviceCompletions offers the devices Supervisor reports as
-// mountable, offering nothing at all if it cannot ask: a host without UDisks2
-// returns an empty list, and a Supervisor predating the endpoint returns 404.
+// Completions for --device from Supervisor candidates. Empty or 404 yields none.
 func mountsCandidatesDeviceCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	resp, err := helper.GenericJSONGet("mounts", "candidates")
 	if err != nil || !resp.IsSuccess() {
@@ -91,7 +89,7 @@ func mountCandidateDescription(candidate map[string]any) string {
 	return strings.Join(ds, ", ")
 }
 
-// humanizeMountSize uses decimal units, the way drive capacity is labelled.
+// Decimal units, matching how drive capacity is labelled.
 func humanizeMountSize(size float64) string {
 	units := []string{"B", "kB", "MB", "GB", "TB"}
 	i := 0

--- a/cmd/mounts_update.go
+++ b/cmd/mounts_update.go
@@ -16,6 +16,7 @@ Update or change the configuration of an existing mount in Supervisor.
 `,
 	Example: `
   ha mounts update my_share --usage media --type cifs --server server.local --share media
+  ha mounts update media_disk --usage media --type disk --device /dev/sda1
 `,
 	ValidArgsFunction: mountsCompletions,
 	Args:              cobra.ExactArgs(1),
@@ -32,7 +33,7 @@ Update or change the configuration of an existing mount in Supervisor.
 			return
 		}
 
-		request := helper.GetJSONRequest()
+		request := helper.GetJSONRequestTimeout(helper.MountTimeout)
 
 		name := args[0]
 		options := make(map[string]any)


### PR DESCRIPTION
## Proposed change

Support the new `disk` mount type from the Supervisor mount API (home-assistant/supervisor#7137):

- `--device` / `--uuid` flags for `ha mounts add`/`update`, with `disk` offered for `--type`
- New `ha mounts candidates` command listing the local devices Supervisor reports as mountable, also used to complete `--device`
- Mount completions now describe disk mounts (uuid, filesystem) instead of showing nothing
- `add`/`update` only send the flags the user actually set, so updating one field no longer silently rewrites the mount type to the flag default
- `add`/`update` use the same timeout as `reload`, since Supervisor mounts the device while handling the request