### PR TITLE
Fix HA URL when SSL is enabled and omit default scheme's port on the banner

### DIFF
--- a/cmd/banner.go
+++ b/cmd/banner.go
@@ -169,7 +169,7 @@ var bannerCmd = &cobra.Command{
 
 		protocol := "http"
 		defaultPort := 80
-		if (*coreinfo)["ssl"] == "true" {
+		if ssl, _ := (*coreinfo)["ssl"].(bool); ssl {
 			protocol = "https"
 			defaultPort = 443
 		}

--- a/cmd/banner.go
+++ b/cmd/banner.go
@@ -168,15 +168,22 @@ var bannerCmd = &cobra.Command{
 		}
 
 		protocol := "http"
+		defaultPort := 80
 		if (*coreinfo)["ssl"] == "true" {
 			protocol = "https"
+			defaultPort = 443
 		}
 
 		port, _ := (*coreinfo)["port"].(float64)
+		coreURL := fmt.Sprintf("%s://%s.local", protocol, (*hostinfo)["hostname"])
+		if int(port) != defaultPort {
+			coreURL = fmt.Sprintf("%s:%d", coreURL, int(port))
+		}
+
 		fmt.Printf("  %-25s %s\n", "OS Version:", (*hostinfo)["operating_system"])
 		fmt.Printf("  %-25s %s\n", "Home Assistant Core:", (*coreinfo)["version"])
 		fmt.Println()
-		fmt.Printf("  %-25s %s://%s.local:%d\n", "Home Assistant URL:", protocol, (*hostinfo)["hostname"], int(port))
+		fmt.Printf("  %-25s %s\n", "Home Assistant URL:", coreURL)
 		fmt.Printf("  %-25s http://%s.local:%d\n", "Observer URL:", (*hostinfo)["hostname"], 4357)
 		fmt.Println("")
 		fmt.Println("System is ready! Use browser or app to configure.")


### PR DESCRIPTION
When HA is running on the scheme's default port (80 for HTTP, 443 for HTTPS), do not add it as a port suffix to the HA URL on the banner.

Similar to home-assistant/supervisor#7153
Refs home-assistant/operating-system#4949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Home Assistant URLs now use standard HTTP and HTTPS ports without displaying them unnecessarily.
  * Custom, non-standard ports continue to be included in generated URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->