### PR TITLE
Add `docker reset-storage` command

### DIFF
--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -14,7 +14,8 @@ Home Assistant is running on. It allows you to do things like use private OCI re
 	Example: `
   ha docker info
   ha docker options
-  ha docker registries`,
+  ha docker registries
+  ha docker reset-storage`,
 }
 
 func init() {

--- a/cmd/docker_reset_storage.go
+++ b/cmd/docker_reset_storage.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"log/slog"
+
+	helper "github.com/home-assistant/cli/client"
+	"github.com/spf13/cobra"
+)
+
+var dockerResetStorageCmd = &cobra.Command{
+	Use:   "reset-storage",
+	Short: "Reset the Docker storage",
+	Long: `
+This command wipes the complete Docker storage on the next reboot. All container
+images, including Supervisor, Home Assistant Core, plugins and apps, are deleted
+and downloaded again once the system is back up.
+
+Configuration and data of Home Assistant and apps are kept, they are stored
+outside of the Docker storage.
+
+Internet connectivity is required for re-download of all the container images.
+A reboot is required to apply the reset.
+`,
+	Example: `
+  ha docker reset-storage
+`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		slog.Debug("docker reset-storage", "args", args)
+
+		section := "docker"
+		command := "reset-storage"
+
+		confirmed, err := helper.AskForConfirmation(`
+This will delete all container images on the next reboot. Supervisor, Home
+Assistant Core, plugins and apps are downloaded again afterwards, which
+requires internet connectivity. Home Assistant and app data are kept.
+
+Once confirmed, the reset will be applied on the next system reboot.
+
+Are you sure you want to proceed?`, 0)
+
+		if err != nil {
+			cmd.PrintErrln("Aborted:", err)
+			ExitWithError = true
+			return
+		}
+
+		if confirmed {
+			resp, err := helper.GenericJSONPost(section, command, nil)
+			if err != nil {
+				helper.PrintError(err)
+				ExitWithError = true
+			} else {
+				ExitWithError = !helper.ShowJSONResponse(resp)
+			}
+		} else {
+			cmd.PrintErrln("Aborted.")
+			ExitWithError = true
+		}
+	},
+}
+
+func init() {
+	dockerCmd.AddCommand(dockerResetStorageCmd)
+}

--- a/cmd/docker_reset_storage.go
+++ b/cmd/docker_reset_storage.go
@@ -15,6 +15,9 @@ This command wipes the complete Docker storage on the next reboot. All container
 images, including Supervisor, Home Assistant Core, plugins and apps, are deleted
 and downloaded again once the system is back up.
 
+Use it to recover from a corrupted or inconsistent Docker storage, for example
+when containers fail to start or images cannot be updated.
+
 Configuration and data of Home Assistant and apps are kept, they are stored
 outside of the Docker storage.
 


### PR DESCRIPTION
Add `ha docker reset-storage`, which posts to the new Supervisor endpoint POST /docker/reset-storage. Supervisor schedules a wipe of the whole Docker storage on the next boot; all container images are re-downloaded, while Home Assistant and app data are kept. A reboot is required to apply the reset. Requires HAOS 18.3+.

Refs home-assistant/supervisor#6555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `docker reset-storage` command.
  * Prompts for confirmation before resetting Docker storage.
  * Reports success or errors after the reset request.

* **Documentation**
  * Updated Docker command usage examples to include storage reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->