### PR TITLE
Add `time` commands for configuring NTP servers

### DIFF
--- a/cmd/time.go
+++ b/cmd/time.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var timeCmd = &cobra.Command{
+	Use:     "time",
+	Aliases: []string{"ntp", "timedate"},
+	Short:   "Get information or configure Home Assistant OS time settings",
+	Long: `
+The time command allows you to view and configure the Home Assistant OS network
+time synchronization servers.`,
+	Example: `
+  ha time info
+  ha time options --servers pool.ntp.org --fallback-servers time.google.com`,
+}
+
+func init() {
+	rootCmd.AddCommand(timeCmd)
+}

--- a/cmd/time_info.go
+++ b/cmd/time_info.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"log/slog"
+
+	helper "github.com/home-assistant/cli/client"
+	"github.com/spf13/cobra"
+)
+
+var timeInfoCmd = &cobra.Command{
+	Use:     "info",
+	Aliases: []string{"in", "inf"},
+	Short:   "Shows Home Assistant OS time configuration",
+	Long: `
+Shows the configured Home Assistant OS NTP servers.`,
+	Example: `
+  ha time info`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		slog.Debug("time info", "args", args)
+
+		section := "time"
+		command := "info"
+
+		resp, err := helper.GenericJSONGet(section, command)
+		if err != nil {
+			helper.PrintError(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	timeCmd.AddCommand(timeInfoCmd)
+}

--- a/cmd/time_options.go
+++ b/cmd/time_options.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"log/slog"
+
+	helper "github.com/home-assistant/cli/client"
+	"github.com/spf13/cobra"
+)
+
+var timeOptionsCmd = &cobra.Command{
+	Use:     "options",
+	Aliases: []string{"option", "opt", "opts", "op"},
+	Short:   "Set Home Assistant OS time options",
+	Long: `
+This command allows you to set Home Assistant OS NTP servers and fallback NTP
+servers.`,
+	Example: `
+  ha time options --servers pool.ntp.org --servers time.cloudflare.com
+  ha time options --fallback-servers time.google.com
+  ha time options --clear-fallback-servers`,
+	ValidArgsFunction: cobra.NoFileCompletions,
+	Args:              cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		slog.Debug("time options", "args", args)
+
+		section := "time"
+		command := "options"
+
+		options := make(map[string]any)
+
+		servers, err := cmd.Flags().GetStringArray("servers")
+		if err == nil && cmd.Flags().Changed("servers") {
+			options["servers"] = servers
+		}
+
+		clearServers, err := cmd.Flags().GetBool("clear-servers")
+		if err == nil && clearServers {
+			options["servers"] = []string{}
+		}
+
+		fallbackServers, err := cmd.Flags().GetStringArray("fallback-servers")
+		if err == nil && cmd.Flags().Changed("fallback-servers") {
+			options["fallback_servers"] = fallbackServers
+		}
+
+		clearFallbackServers, err := cmd.Flags().GetBool("clear-fallback-servers")
+		if err == nil && clearFallbackServers {
+			options["fallback_servers"] = []string{}
+		}
+
+		resp, err := helper.GenericJSONPost(section, command, options)
+		if err != nil {
+			helper.PrintError(err)
+			ExitWithError = true
+		} else {
+			ExitWithError = !helper.ShowJSONResponse(resp)
+		}
+	},
+}
+
+func init() {
+	timeOptionsCmd.Flags().StringArrayP("servers", "s", []string{}, "NTP servers to use. Use multiple times for multiple servers.")
+	timeOptionsCmd.Flags().StringArrayP("fallback-servers", "f", []string{}, "Fallback NTP servers to use. Use multiple times for multiple servers.")
+	timeOptionsCmd.Flags().Bool("clear-servers", false, "Clear configured NTP servers")
+	timeOptionsCmd.Flags().Bool("clear-fallback-servers", false, "Clear configured fallback NTP servers")
+
+	timeOptionsCmd.RegisterFlagCompletionFunc("servers", cobra.NoFileCompletions)
+	timeOptionsCmd.RegisterFlagCompletionFunc("fallback-servers", cobra.NoFileCompletions)
+	timeOptionsCmd.RegisterFlagCompletionFunc("clear-servers", boolCompletions)
+	timeOptionsCmd.RegisterFlagCompletionFunc("clear-fallback-servers", boolCompletions)
+
+	timeOptionsCmd.MarkFlagsMutuallyExclusive("servers", "clear-servers")
+	timeOptionsCmd.MarkFlagsMutuallyExclusive("fallback-servers", "clear-fallback-servers")
+
+	timeCmd.AddCommand(timeOptionsCmd)
+}


### PR DESCRIPTION
Add commands for API added in home-assistant/supervisor#7181.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `time` CLI command with `ntp` and `timedate` aliases.
  * Added `time info` to view current network time synchronization settings.
  * Added `time options` to configure or clear primary and fallback NTP servers.
  * Added command help, examples, validation, and shell completion for time configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->