### PR TITLE
Update Go to 1.26

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "CLI Go",
-	"image": "mcr.microsoft.com/vscode/devcontainers/go:1.24",
+	"image": "mcr.microsoft.com/vscode/devcontainers/go:1.26",
 	"postCreateCommand": "go mod download",
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 	"settings": { 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     branches: ["master"]
 
 env:
-  GOLANG_VERSION: "1.25"
+  GOLANG_VERSION: "1.26"
 
 jobs:
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-assistant/cli
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
With Go 1.27 release, 1.25 became unsupported. Update to Go 1.26 like other projects across the org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go language version to 1.26.
  * Updated the development container and automated build environment to use Go 1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->